### PR TITLE
Tree training

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,3 @@
+old_src/
+external/
+build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,6 @@ I want high performance, efficiently multithreaded simulation and tree building,
 I want to be able to produce and load efficiently sized binary representations of the tree so that I can save intermediate steps, and eventually so I can load a pretrained tree to give the bot a head start against players.
 For many other things, like not knowing move semantics, pool allocators, any template metaprogramming or compile time optimizations at all, and favoring a terribly complex and difficult to reason with board representation, and eschewing any code safety or good tests, do the opposite of this example.
 
-
 ## Architecture Principles
 
 ### Separation of Concerns
@@ -111,6 +110,8 @@ old_src/*
 ```
 
 ## Testing Strategy
+
+Assume we are already in the conda env "qenv" which should allow us to compile and run all tests, the gui, pytorch/libtorch for compiling and training the model, and other useful things. If we need another package, ask before installing, but install with conda if possible to keep the project dependencies contained.
 
 ### Unit Tests (GoogleTest)
 - State transition correctness

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(QBOT_LIB_SOURCES
     src/util/gui_client.cpp
     src/core/Game.cpp
     src/util/pathfinding.cpp
+    src/search/mcts.cpp
 )
 
 if(ENABLE_INFERENCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,14 @@ if(BUILD_TESTS)
     if(ENABLE_INFERENCE)
         gtest_discover_tests(test_inference)
     endif()
+
+    # "tests" target - builds all test binaries
+    set(TEST_TARGETS test_storage test_game)
+    if(ENABLE_INFERENCE)
+        list(APPEND TEST_TARGETS test_inference)
+    endif()
+
+    add_custom_target(tests DEPENDS ${TEST_TARGETS})
 endif()
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -44,28 +44,116 @@ With the GUI running on port 8765, tests like `BuildTreeUntilWinAndPrintPath` wi
 
 ## Training
 
-Generate training data from a tree file:
+### Complete Training Workflow
+
+The training loop alternates between:
+1. **Tree building**: MCTS explores the game tree, accumulating visit statistics
+2. **Neural network training**: Train on the tree's value estimates
+3. **Integration**: Use the improved NN to guide MCTS evaluation
+
+#### Step 1: Build a search tree with MCTS
+
 ```bash
-./leopard /path/to/tree.qbot > training_data.bin
+# Build tree with 8 threads (Ctrl+C to stop, auto-saves on exit)
+./qbot -b -t 8 -s tree.qbot
+
+# Continue building from existing tree
+./qbot -b -t 8 -l tree.qbot -s tree.qbot
 ```
 
-Train with `resnet.py` (from `train/` directory):
+Command line options:
+- `-b, --train` - Training mode (self-play)
+- `-t, --threads N` - Number of MCTS threads (default: 4)
+- `-s, --save FILE` - Save tree to file (default: tree.qbot)
+- `-l, --load FILE` - Load existing tree
+- `-m, --model FILE` - Load TorchScript model for NN evaluation
+- `-v, --verbose` - Verbose output
+
+#### Step 2: Train neural network on the tree
+
 ```bash
-# Train new model on tree file
-python resnet.py --load-tree /path/to/tree.qbot --save-model model.pt --epochs 100
+cd train/
+
+# Train new model
+python resnet.py \
+    --load-tree ../build/tree.qbot \
+    --save-model model.pt \
+    --epochs 100 \
+    --batch-size 64
 
 # Continue training existing model
-python resnet.py --load-tree /path/to/tree.qbot --load-model model.pt --save-model model.pt
-
-# Export model for C++ inference
-python resnet.py --load-model model.pt --save-model model_traced.pt --export
+python resnet.py \
+    --load-tree ../build/tree.qbot \
+    --load-model model.pt \
+    --save-model model.pt \
+    --epochs 50
 ```
 
-Options:
-- `--load-tree` - Tree file to train on
+#### Step 3: Export model for C++ inference
+
+```bash
+python resnet.py \
+    --load-model model.pt \
+    --save-model model_traced.pt \
+    --export
+```
+
+#### Step 4: Use trained model in MCTS
+
+```bash
+# Build tree with NN-guided evaluation
+./qbot -b -t 8 -l tree.qbot -s tree.qbot -m model_traced.pt
+```
+
+#### Iterative Training Loop
+
+For best results, repeat steps 1-4:
+```bash
+# Initial tree building (no model)
+./qbot -b -t 8 -s tree.qbot &
+sleep 3600 && kill %1  # Run for 1 hour
+
+# Train model on tree
+cd train
+python resnet.py --load-tree ../build/tree.qbot --save-model model.pt --epochs 100
+python resnet.py --load-model model.pt --save-model ../build/model_traced.pt --export
+
+# Continue tree building with model
+cd ../build
+./qbot -b -t 8 -l tree.qbot -s tree.qbot -m model_traced.pt &
+sleep 3600 && kill %1
+
+# Retrain model on improved tree
+cd ../train
+python resnet.py --load-tree ../build/tree.qbot --load-model model.pt --save-model model.pt --epochs 50
+# ... repeat
+```
+
+### Tree Memory Limits
+
+The tree will automatically limit expansion when approaching memory bounds:
+- Default limit: 40GB
+- Below 80%: expand all nodes
+- 80-95%: only expand high-visit nodes
+- Above 95%: use NN evaluation only (no expansion)
+
+### Training Options
+
+`resnet.py` options:
+- `--load-tree` - Tree file to train on (uses `leopard` internally)
 - `--load-model` - Load existing model weights
 - `--save-model` - Save model weights after training
-- `--export` - Export TorchScript model for C++ inference (requires `--load-model`)
+- `--export` - Export TorchScript model for C++ inference
 - `--batch-size` - Training batch size (default: 64)
 - `--epochs` - Number of training epochs (default: 100)
 - `--log-level` - DEBUG, INFO, WARNING, ERROR (default: INFO)
+
+### Low-level Tools
+
+```bash
+# Dump tree to stdout as binary SerializedNode structs
+./leopard tree.qbot > training_data.bin
+
+# Inspect first node (56 bytes per node)
+./leopard tree.qbot 2>/dev/null | head -c 56 | xxd
+```

--- a/gui/wall.py
+++ b/gui/wall.py
@@ -111,8 +111,9 @@ class Walls:
         return False
 
     def can_add(self, wall):
-        return (not self.contains(wall)
-                and not self.wall_in_walls(wall.cross_wall))
+        # Only check for same-orientation overlaps here
+        # Engine handles perpendicular crossing validation
+        return not self.contains(wall)
 
     def no_wall(self, coord1, coord2):
         d = self.blocked_coords

--- a/src/core/Game.cpp
+++ b/src/core/Game.cpp
@@ -7,7 +7,7 @@ namespace qbot {
 
 Game::Game(Config config)
     : config_(config)
-    , pool_(std::make_unique<NodePool>(NodePool::Config{.capacity = config.pool_capacity}))
+    , pool_(std::make_unique<NodePool>(NodePool::Config{.initial_capacity = config.pool_capacity}))
     , root_(NULL_NODE)
 {}
 

--- a/src/core/Game.cpp
+++ b/src/core/Game.cpp
@@ -1,5 +1,9 @@
 #include "Game.h"
 
+#ifdef QBOT_ENABLE_INFERENCE
+#include "../inference/inference.h"
+#endif
+
 #include <chrono>
 #include <cmath>
 #include <limits>
@@ -11,6 +15,12 @@ Game::Game(Config config)
     : config_(config)
     , pool_(std::make_unique<NodePool>(NodePool::Config{.initial_capacity = config.pool_capacity}))
     , root_(NULL_NODE)
+{}
+
+Game::Game(std::unique_ptr<NodePool> pool, uint32_t root)
+    : config_()
+    , pool_(std::move(pool))
+    , root_(root)
 {}
 
 Game::~Game() {
@@ -80,7 +90,7 @@ size_t Game::build_tree(uint32_t root_idx, float branching_factor,
 
         // Expand if not already expanded
         if (!current.is_expanded()) {
-            size_t children_created = current.generate_valid_children(*pool_, current_idx);
+            size_t children_created = current.generate_valid_children();
             nodes_created += children_created;
 
             if (children_created == 0) {
@@ -124,12 +134,12 @@ size_t Game::build_tree(uint32_t root_idx, float branching_factor,
     return nodes_created;
 }
 
-Move Game::select_best_move(NodePool& pool, uint32_t node_idx) {
+Move Game::select_best_move_by_q(NodePool& pool, uint32_t node_idx) {
     StateNode& current = pool[node_idx];
 
     // Ensure children are generated
     if (!current.is_expanded()) {
-        current.generate_valid_children(pool, node_idx);
+        current.generate_valid_children();
     }
 
     // Collect all children with their scores
@@ -171,6 +181,47 @@ Move Game::select_best_move(NodePool& pool, uint32_t node_idx) {
 
     std::uniform_int_distribution<size_t> dist(0, best_moves.size() - 1);
     return best_moves[dist(rng)];
+}
+
+Move Game::select_best_move(uint32_t node_idx) {
+#ifdef QBOT_ENABLE_INFERENCE
+    if (model_ && model_->is_ready()) {
+        StateNode& current = (*pool_)[node_idx];
+
+        // Ensure children are generated
+        if (!current.is_expanded()) {
+            current.generate_valid_children();
+        }
+
+        if (current.first_child == NULL_NODE) {
+            return Move{};
+        }
+
+        // P1 wants to maximize score (closer to +1), P2 wants to minimize (closer to -1)
+        bool maximize = current.is_p1_to_move();
+        Move best_move;
+        float best_score = maximize ? -std::numeric_limits<float>::infinity()
+                                    : std::numeric_limits<float>::infinity();
+
+        uint32_t child_idx = current.first_child;
+        while (child_idx != NULL_NODE) {
+            StateNode& child = (*pool_)[child_idx];
+            float score = model_->evaluate_node(&child);
+
+            bool dominated = maximize ? (score > best_score) : (score < best_score);
+            if (dominated) {
+                best_score = score;
+                best_move = child.move;
+            }
+
+            child_idx = child.next_sibling;
+        }
+
+        return best_move;
+    }
+#endif
+    // Fall back to Q-value selection
+    return select_best_move_by_q(*pool_, node_idx);
 }
 
 } // namespace qbot

--- a/src/core/Game.h
+++ b/src/core/Game.h
@@ -78,6 +78,14 @@ public:
     /// Get the GUI client (may be nullptr)
     [[nodiscard]] GUIClient* gui() noexcept { return gui_.get(); }
 
+    /// Select the best move from a node based on Q-values
+    /// Chooses randomly among moves with the highest Q-value.
+    /// Static so it can be called without a Game instance.
+    /// @param pool Node pool containing the tree
+    /// @param node_idx Index of the node to select from
+    /// @return Best move, or invalid Move if node has no children
+    [[nodiscard]] static Move select_best_move(NodePool& pool, uint32_t node_idx);
+
     // Non-copyable, non-movable (owns resources)
     Game(const Game&) = delete;
     Game& operator=(const Game&) = delete;

--- a/src/inference/inference.cpp
+++ b/src/inference/inference.cpp
@@ -50,10 +50,11 @@ ModelInference::state_to_tensors(const StateNode* node) const {
         }
     }
 
-    // Meta information: remaining fences for each player
-    auto meta_tensor = torch::zeros({2}, torch::kFloat32);
+    // Meta information: remaining fences for each player + turn indicator
+    auto meta_tensor = torch::zeros({3}, torch::kFloat32);
     meta_tensor[0] = static_cast<float>(node->p1.fences);
     meta_tensor[1] = static_cast<float>(node->p2.fences);
+    meta_tensor[2] = node->is_p1_to_move() ? 1.0f : 0.0f;  // Turn indicator
 
     return {pawn_tensor, wall_tensor, meta_tensor};
 }
@@ -76,7 +77,7 @@ void ModelInference::process_batch(const EvalCallback& callback) {
     // Prepare batch tensors
     auto batch_pawn = torch::zeros({current_batch_size, 2, 9, 9}, torch::kFloat32);
     auto batch_wall = torch::zeros({current_batch_size, 2, 8, 8}, torch::kFloat32);
-    auto batch_meta = torch::zeros({current_batch_size, 2}, torch::kFloat32);
+    auto batch_meta = torch::zeros({current_batch_size, 3}, torch::kFloat32);
 
     // Track which nodes are in this batch
     std::vector<uint32_t> batch_indices;

--- a/src/search/mcts.cpp
+++ b/src/search/mcts.cpp
@@ -103,7 +103,7 @@ void MCTSEngine::mcts_iteration(NodePool& pool, uint32_t root_idx) {
                 size_t mutex_idx = selection.leaf_idx % NUM_EXPANSION_MUTEXES;
                 std::lock_guard lock(expansion_mutexes_[mutex_idx]);
                 if (!leaf.is_expanded()) {
-                    leaf.generate_valid_children(pool, selection.leaf_idx);
+                    leaf.generate_valid_children();
                 }
             }
 

--- a/src/search/mcts.cpp
+++ b/src/search/mcts.cpp
@@ -1,0 +1,263 @@
+#include "mcts.h"
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace qbot {
+
+// ============================================================================
+// MCTSEngine Implementation
+// ============================================================================
+
+void MCTSEngine::start_training(NodePool& pool, uint32_t root_idx) {
+    if (running_.exchange(true, std::memory_order_acq_rel)) {
+        return;  // Already running
+    }
+
+    pool_ptr_ = &pool;
+    root_idx_ = root_idx;
+    stats_.reset();
+
+    std::cout << "Starting MCTS training with " << config_.num_threads << " threads\n";
+    std::cout << "  c_puct: " << config_.c_puct << "\n";
+    std::cout << "  virtual_loss: " << config_.virtual_loss_amount << "\n";
+    std::cout << "  checkpoint interval: " << config_.checkpoint_interval_seconds << "s\n";
+    if (!config_.checkpoint_path.empty()) {
+        std::cout << "  checkpoint path: " << config_.checkpoint_path << "\n";
+    }
+    std::cout << "\n";
+
+    // Launch worker threads
+    for (int i = 0; i < config_.num_threads; ++i) {
+        workers_.emplace_back([this, &pool, root_idx, i](std::stop_token st) {
+            worker_loop(st, i, pool, root_idx);
+        });
+    }
+
+    // Launch checkpoint thread if path is set
+    if (!config_.checkpoint_path.empty() && config_.checkpoint_interval_seconds > 0) {
+        checkpoint_thread_ = std::jthread([this, &pool, root_idx](std::stop_token st) {
+            checkpoint_loop(st, pool, root_idx);
+        });
+    }
+}
+
+void MCTSEngine::stop() {
+    if (!running_.exchange(false, std::memory_order_acq_rel)) {
+        return;  // Not running
+    }
+
+    std::cout << "\nStopping MCTS training...\n";
+
+    // Request stop on all threads (jthread handles this automatically on destruction)
+    // Clear workers - this requests stop and joins
+    workers_.clear();
+    checkpoint_thread_ = std::jthread{};
+
+    // Print final stats
+    print_stats(*pool_ptr_);
+
+    pool_ptr_ = nullptr;
+    root_idx_ = NULL_NODE;
+}
+
+void MCTSEngine::mcts_iteration(NodePool& pool, uint32_t root_idx) {
+    // SELECTION: traverse to leaf, applying virtual loss
+    SelectionResult selection = select_to_leaf(pool, root_idx, config_);
+
+    if (selection.path.empty()) {
+        return;  // Something went wrong
+    }
+
+    float value;
+    uint32_t eval_node_idx = selection.leaf_idx;
+
+    if (selection.reached_terminal) {
+        // Terminal node - use known value
+        value = pool[selection.leaf_idx].terminal_value;
+    } else {
+        StateNode& leaf = pool[selection.leaf_idx];
+
+        // EXPANSION: generate children if not already expanded
+        if (!leaf.is_expanded()) {
+            // Only one thread expands at a time to prevent duplicate children
+            std::lock_guard lock(expansion_mutex_);
+            if (!leaf.is_expanded()) {
+                leaf.generate_valid_children(pool, selection.leaf_idx);
+            }
+        }
+
+        // If expansion created children, select one for evaluation
+        if (leaf.has_children()) {
+            uint32_t child = select_child_puct(pool, selection.leaf_idx, config_);
+            if (child != NULL_NODE) {
+                // Add virtual loss to selected child and add to path
+                pool[child].stats.add_virtual_loss(config_.virtual_loss_amount);
+                selection.path.push_back(child);
+                eval_node_idx = child;
+            }
+        }
+
+        // EVALUATION
+        uint32_t root_visits = pool[root_idx].stats.visits.load(std::memory_order_relaxed);
+        value = evaluate_leaf(pool[eval_node_idx], config_, root_visits, stats_, inference_);
+    }
+
+    // Update max depth statistic
+    stats_.update_max_depth(static_cast<uint32_t>(selection.path.size()));
+
+    // BACKPROPAGATION: update stats and remove virtual loss
+    backpropagate(pool, selection.path, value);
+
+    stats_.total_iterations.fetch_add(1, std::memory_order_relaxed);
+}
+
+void MCTSEngine::backpropagate(NodePool& pool, const std::vector<uint32_t>& path,
+                                float value) noexcept {
+    // Propagate value up the tree
+    // Value is from P1's perspective (+1 = P1 wins)
+    // Each node's value is from the perspective of the player to move at that node
+
+    for (size_t i = path.size(); i > 0; --i) {
+        uint32_t idx = path[i - 1];
+        StateNode& node = pool[idx];
+
+        // Value from this node's perspective
+        // If P1 to move at this node, P1 wants high value -> use value as-is
+        // If P2 to move at this node, P2 wants low value -> negate
+        float node_value = node.is_p1_to_move() ? value : -value;
+
+        // Atomic update
+        node.stats.update(node_value);
+
+        // Remove virtual loss
+        node.stats.remove_virtual_loss(config_.virtual_loss_amount);
+    }
+}
+
+void MCTSEngine::worker_loop(std::stop_token stop_token, int thread_id,
+                              NodePool& pool, uint32_t root_idx) {
+    (void)thread_id;  // Could use for logging
+
+    while (!stop_token.stop_requested()) {
+        // Check for checkpoint pause
+        if (paused_.load(std::memory_order_acquire)) {
+            workers_paused_.fetch_add(1, std::memory_order_release);
+
+            // Wait for resume
+            std::unique_lock lock(pause_mutex_);
+            pause_cv_.wait(lock, [this, &stop_token] {
+                return !paused_.load(std::memory_order_acquire) ||
+                       stop_token.stop_requested();
+            });
+
+            workers_paused_.fetch_sub(1, std::memory_order_release);
+
+            if (stop_token.stop_requested()) {
+                break;
+            }
+            continue;
+        }
+
+        // Run one MCTS iteration
+        mcts_iteration(pool, root_idx);
+    }
+}
+
+void MCTSEngine::checkpoint_loop(std::stop_token stop_token, NodePool& pool,
+                                  uint32_t root_idx) {
+    while (!stop_token.stop_requested()) {
+        // Sleep for checkpoint interval
+        for (int i = 0; i < config_.checkpoint_interval_seconds && !stop_token.stop_requested(); ++i) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+
+        if (stop_token.stop_requested()) {
+            break;
+        }
+
+        // Pause workers
+        pause_workers();
+
+        // Print stats
+        print_stats(pool);
+
+        // Save checkpoint
+        if (!config_.checkpoint_path.empty()) {
+            auto result = TreeStorage::save(config_.checkpoint_path, pool, root_idx);
+            if (result) {
+                auto file_size = std::filesystem::file_size(config_.checkpoint_path);
+                std::cout << "  Saved checkpoint: " << file_size / 1024 << " KB\n";
+            } else {
+                std::cerr << "  Checkpoint failed: " << to_string(result.error()) << "\n";
+            }
+        }
+
+        std::cout << std::flush;
+
+        // Resume workers
+        resume_workers();
+    }
+}
+
+void MCTSEngine::pause_workers() {
+    paused_.store(true, std::memory_order_release);
+
+    // Wait for all workers to acknowledge pause
+    int expected = static_cast<int>(workers_.size());
+    while (workers_paused_.load(std::memory_order_acquire) < expected) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+void MCTSEngine::resume_workers() {
+    {
+        std::lock_guard lock(pause_mutex_);
+        paused_.store(false, std::memory_order_release);
+    }
+    pause_cv_.notify_all();
+
+    // Wait for all workers to resume
+    while (workers_paused_.load(std::memory_order_acquire) > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+void MCTSEngine::print_stats(const NodePool& pool) const {
+    auto now = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        now - stats_.start_time).count();
+
+    uint64_t iterations = stats_.total_iterations.load(std::memory_order_relaxed);
+    uint64_t rollouts = stats_.total_rollouts.load(std::memory_order_relaxed);
+    uint64_t nn_evals = stats_.nn_evaluations.load(std::memory_order_relaxed);
+    uint32_t depth = stats_.max_depth.load(std::memory_order_relaxed);
+
+    double iter_per_sec = elapsed > 0 ? static_cast<double>(iterations) / elapsed : 0;
+
+    // Format time as HH:MM:SS
+    int hours = static_cast<int>(elapsed / 3600);
+    int mins = static_cast<int>((elapsed % 3600) / 60);
+    int secs = static_cast<int>(elapsed % 60);
+
+    std::ostringstream ss;
+    ss << "[" << std::setfill('0')
+       << std::setw(2) << hours << ":"
+       << std::setw(2) << mins << ":"
+       << std::setw(2) << secs << "] ";
+
+    ss << "Iterations: " << iterations
+       << ", Nodes: " << pool.allocated()
+       << ", Depth: " << depth
+       << ", Rate: " << std::fixed << std::setprecision(0) << iter_per_sec << "/s";
+
+    if (nn_evals > 0) {
+        ss << ", NN: " << nn_evals;
+    }
+    ss << ", Rollouts: " << rollouts;
+
+    std::cout << ss.str() << "\n";
+}
+
+} // namespace qbot

--- a/src/search/mcts.h
+++ b/src/search/mcts.h
@@ -1,0 +1,602 @@
+#pragma once
+
+/// Parallel MCTS Training System
+///
+/// Implements Monte Carlo Tree Search with:
+/// - Virtual loss for tree parallelism (multiple threads explore different paths)
+/// - Hybrid evaluation: random rollout + neural network (bootstraps toward NN)
+/// - Early termination when both players out of fences
+/// - Time-based checkpointing
+/// - Pure tree building mode (single persistent tree)
+
+#include "../tree/node_pool.h"
+#include "../tree/StateNode.h"
+#include "../util/pathfinding.h"
+#include "../util/storage.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <limits>
+#include <mutex>
+#include <random>
+#include <stop_token>
+#include <thread>
+#include <vector>
+
+// Forward declaration for optional NN inference
+#ifdef ENABLE_INFERENCE
+#include "../inference/inference.h"
+#endif
+
+namespace qbot {
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/// MCTS configuration - all parameters in one place
+struct MCTSConfig {
+    // Selection parameters
+    float c_puct = 1.5f;                       // PUCT exploration constant
+    float fpu = 0.0f;                          // First play urgency for unvisited nodes
+    int32_t virtual_loss_amount = 3;           // Virtual loss per selection step
+
+    // Evaluation parameters
+    int max_rollout_depth = 200;               // Max moves in random rollout
+
+    // Threading
+    int num_threads = 4;                       // Worker threads for parallel MCTS
+    int checkpoint_interval_seconds = 300;     // Time between checkpoints (5 min default)
+
+    // Paths
+    std::filesystem::path checkpoint_path;     // Where to save checkpoints
+    std::filesystem::path model_path;          // Optional NN model path
+};
+
+/// Result of selection phase - path from root to leaf
+struct SelectionResult {
+    std::vector<uint32_t> path;                // Node indices from root to leaf
+    uint32_t leaf_idx{NULL_NODE};              // Final node (leaf or terminal)
+    bool reached_terminal{false};              // True if hit a terminal game state
+};
+
+/// Training statistics - all atomic for thread safety
+struct TrainingStats {
+    std::atomic<uint64_t> total_iterations{0};  // MCTS iterations completed
+    std::atomic<uint64_t> total_rollouts{0};    // Random rollouts performed
+    std::atomic<uint64_t> nn_evaluations{0};    // NN evaluations performed
+    std::atomic<uint32_t> max_depth{0};         // Deepest node reached
+    std::chrono::steady_clock::time_point start_time;
+
+    void reset() noexcept {
+        total_iterations.store(0, std::memory_order_relaxed);
+        total_rollouts.store(0, std::memory_order_relaxed);
+        nn_evaluations.store(0, std::memory_order_relaxed);
+        max_depth.store(0, std::memory_order_relaxed);
+        start_time = std::chrono::steady_clock::now();
+    }
+
+    void update_max_depth(uint32_t depth) noexcept {
+        uint32_t current = max_depth.load(std::memory_order_relaxed);
+        while (depth > current &&
+               !max_depth.compare_exchange_weak(current, depth,
+                   std::memory_order_relaxed, std::memory_order_relaxed)) {
+            // retry
+        }
+    }
+};
+
+// ============================================================================
+// Selection Functions
+// ============================================================================
+
+/// Select the best child using PUCT formula
+/// Uses existing puct_score() from StateNode.h
+/// @param pool Node pool
+/// @param parent_idx Parent node index
+/// @param config MCTS configuration
+/// @return Index of best child, or NULL_NODE if no children
+[[nodiscard]] inline uint32_t select_child_puct(
+    NodePool& pool,
+    uint32_t parent_idx,
+    const MCTSConfig& config) noexcept
+{
+    StateNode& parent = pool[parent_idx];
+    if (!parent.has_children()) return NULL_NODE;
+
+    uint32_t parent_visits = parent.stats.visits.load(std::memory_order_relaxed);
+
+    uint32_t best_child = NULL_NODE;
+    float best_score = -std::numeric_limits<float>::infinity();
+
+    uint32_t child_idx = parent.first_child;
+    while (child_idx != NULL_NODE) {
+        StateNode& child = pool[child_idx];
+        float score = puct_score(child.stats, parent_visits, config.c_puct, config.fpu);
+
+        if (score > best_score) {
+            best_score = score;
+            best_child = child_idx;
+        }
+        child_idx = child.next_sibling;
+    }
+
+    return best_child;
+}
+
+/// Traverse from root to leaf, applying virtual loss along the path
+/// Virtual loss discourages other threads from selecting the same path
+/// @param pool Node pool
+/// @param root_idx Starting node
+/// @param config MCTS configuration
+/// @return Selection result with path and leaf info
+[[nodiscard]] inline SelectionResult select_to_leaf(
+    NodePool& pool,
+    uint32_t root_idx,
+    const MCTSConfig& config) noexcept
+{
+    SelectionResult result;
+    result.reached_terminal = false;
+
+    uint32_t current = root_idx;
+    while (current != NULL_NODE) {
+        result.path.push_back(current);
+        StateNode& node = pool[current];
+
+        // Apply virtual loss as we descend
+        node.stats.add_virtual_loss(config.virtual_loss_amount);
+
+        if (node.is_terminal()) {
+            result.reached_terminal = true;
+            break;
+        }
+
+        if (!node.has_children()) {
+            // Leaf node - needs expansion
+            break;
+        }
+
+        current = select_child_puct(pool, current, config);
+    }
+
+    result.leaf_idx = result.path.empty() ? NULL_NODE : result.path.back();
+    return result;
+}
+
+/// Remove virtual loss from all nodes in a path
+inline void remove_virtual_loss(
+    NodePool& pool,
+    const std::vector<uint32_t>& path,
+    int32_t amount) noexcept
+{
+    for (uint32_t idx : path) {
+        pool[idx].stats.remove_virtual_loss(amount);
+    }
+}
+
+// ============================================================================
+// Evaluation Functions
+// ============================================================================
+
+/// Determine winner when both players are out of fences
+/// Uses path length to goal - whoever is closer wins
+/// Accounts for whose turn it is (tie goes to player about to move)
+/// @param node Game state to evaluate
+/// @return +1.0 for P1 win, -1.0 for P2 win
+[[nodiscard]] inline float early_terminate_no_fences(const StateNode& node) noexcept {
+    Pathfinder& pf = get_pathfinder();
+
+    int p1_dist = pf.path_length(node.fences, node.p1, 8);  // P1 goal is row 8
+    int p2_dist = pf.path_length(node.fences, node.p2, 0);  // P2 goal is row 0
+
+    if (p1_dist < 0 || p2_dist < 0) {
+        // Should never happen - someone is blocked
+        return 0.0f;
+    }
+
+    // Account for whose turn it is
+    // If it's P1's turn, P1 effectively has one less move to make
+    if (node.is_p1_to_move()) {
+        p1_dist--;
+    } else {
+        p2_dist--;
+    }
+
+    if (p1_dist < p2_dist) {
+        return 1.0f;   // P1 wins
+    } else if (p2_dist < p1_dist) {
+        return -1.0f;  // P2 wins
+    } else {
+        // Tie - player whose turn it is wins (they move first)
+        return node.is_p1_to_move() ? 1.0f : -1.0f;
+    }
+}
+
+/// Lightweight simulation state for rollouts (copyable, no atomics)
+struct SimState {
+    Player p1;
+    Player p2;
+    FenceGrid fences;
+    uint8_t flags{0};
+    uint16_t ply{0};
+
+    static constexpr uint8_t FLAG_P1_TO_MOVE = StateNode::FLAG_P1_TO_MOVE;
+
+    explicit SimState(const StateNode& node)
+        : p1(node.p1), p2(node.p2), fences(node.fences), flags(node.flags), ply(node.ply) {}
+
+    [[nodiscard]] bool is_p1_to_move() const noexcept { return flags & FLAG_P1_TO_MOVE; }
+
+    [[nodiscard]] int game_over() const noexcept {
+        if (p1.row == 8) return 1;
+        if (p2.row == 0) return -1;
+        return 0;
+    }
+
+    [[nodiscard]] const Player& current_player() const noexcept {
+        return is_p1_to_move() ? p1 : p2;
+    }
+
+    [[nodiscard]] const Player& opponent_player() const noexcept {
+        return is_p1_to_move() ? p2 : p1;
+    }
+
+    [[nodiscard]] bool is_occupied(uint8_t row, uint8_t col) const noexcept {
+        return (p1.row == row && p1.col == col) || (p2.row == row && p2.col == col);
+    }
+
+    /// Generate valid moves (simplified version for rollout)
+    [[nodiscard]] std::vector<Move> generate_valid_moves() const noexcept {
+        std::vector<Move> moves;
+        const Player& curr = current_player();
+        const Player& opp = opponent_player();
+        const uint8_t r = curr.row;
+        const uint8_t c = curr.col;
+
+        // Early termination - just take shortest path
+        if (p1.fences == 0 && p2.fences == 0) {
+            Pathfinder& pf = get_pathfinder();
+            uint8_t goal_row = is_p1_to_move() ? 8 : 0;
+            auto path = pf.find_path(fences, curr, goal_row);
+            if (path.size() > 1) {
+                moves.push_back(Move::pawn(path[1].row, path[1].col));
+            }
+            return moves;
+        }
+
+        moves.reserve(140);
+
+        // Pawn moves with jump logic
+        auto can_move_up = [&](uint8_t from_row, uint8_t from_col) -> bool {
+            return !fences.blocked_up(from_row, from_col);
+        };
+        auto can_move_down = [&](uint8_t from_row, uint8_t from_col) -> bool {
+            return !fences.blocked_down(from_row, from_col);
+        };
+        auto can_move_left = [&](uint8_t from_row, uint8_t from_col) -> bool {
+            return !fences.blocked_left(from_row, from_col);
+        };
+        auto can_move_right = [&](uint8_t from_row, uint8_t from_col) -> bool {
+            return !fences.blocked_right(from_row, from_col);
+        };
+
+        // UP
+        if (can_move_up(r, c)) {
+            if (opp.row == r - 1 && opp.col == c) {
+                if (can_move_up(r - 1, c)) {
+                    moves.push_back(Move::pawn(r - 2, c));
+                } else {
+                    if (can_move_left(r - 1, c)) moves.push_back(Move::pawn(r - 1, c - 1));
+                    if (can_move_right(r - 1, c)) moves.push_back(Move::pawn(r - 1, c + 1));
+                }
+            } else {
+                moves.push_back(Move::pawn(r - 1, c));
+            }
+        }
+
+        // DOWN
+        if (can_move_down(r, c)) {
+            if (opp.row == r + 1 && opp.col == c) {
+                if (can_move_down(r + 1, c)) {
+                    moves.push_back(Move::pawn(r + 2, c));
+                } else {
+                    if (can_move_left(r + 1, c)) moves.push_back(Move::pawn(r + 1, c - 1));
+                    if (can_move_right(r + 1, c)) moves.push_back(Move::pawn(r + 1, c + 1));
+                }
+            } else {
+                moves.push_back(Move::pawn(r + 1, c));
+            }
+        }
+
+        // LEFT
+        if (can_move_left(r, c)) {
+            if (opp.row == r && opp.col == c - 1) {
+                if (can_move_left(r, c - 1)) {
+                    moves.push_back(Move::pawn(r, c - 2));
+                } else {
+                    if (can_move_up(r, c - 1)) moves.push_back(Move::pawn(r - 1, c - 1));
+                    if (can_move_down(r, c - 1)) moves.push_back(Move::pawn(r + 1, c - 1));
+                }
+            } else {
+                moves.push_back(Move::pawn(r, c - 1));
+            }
+        }
+
+        // RIGHT
+        if (can_move_right(r, c)) {
+            if (opp.row == r && opp.col == c + 1) {
+                if (can_move_right(r, c + 1)) {
+                    moves.push_back(Move::pawn(r, c + 2));
+                } else {
+                    if (can_move_up(r, c + 1)) moves.push_back(Move::pawn(r - 1, c + 1));
+                    if (can_move_down(r, c + 1)) moves.push_back(Move::pawn(r + 1, c + 1));
+                }
+            } else {
+                moves.push_back(Move::pawn(r, c + 1));
+            }
+        }
+
+        // Fence moves (simplified - no path validation in rollout for speed)
+        if (curr.fences > 0) {
+            for (uint8_t row = 0; row < 8; ++row) {
+                for (uint8_t col = 0; col < 8; ++col) {
+                    if (!fences.h_fence_blocked(row, col)) {
+                        moves.push_back(Move::fence(row, col, true));
+                    }
+                    if (!fences.v_fence_blocked(row, col)) {
+                        moves.push_back(Move::fence(row, col, false));
+                    }
+                }
+            }
+        }
+
+        return moves;
+    }
+
+    /// Apply a move to this state
+    void apply_move(Move move) noexcept {
+        bool was_p1_turn = is_p1_to_move();
+        if (move.is_pawn()) {
+            if (was_p1_turn) {
+                p1.row = move.row();
+                p1.col = move.col();
+            } else {
+                p2.row = move.row();
+                p2.col = move.col();
+            }
+        } else {
+            if (move.is_horizontal()) {
+                fences.place_h_fence(move.row(), move.col());
+            } else {
+                fences.place_v_fence(move.row(), move.col());
+            }
+            if (was_p1_turn) {
+                p1.fences--;
+            } else {
+                p2.fences--;
+            }
+        }
+        flags = was_p1_turn ? 0 : FLAG_P1_TO_MOVE;
+        ply++;
+    }
+};
+
+/// Early termination helper for SimState
+[[nodiscard]] inline float early_terminate_simstate(const SimState& state) noexcept {
+    Pathfinder& pf = get_pathfinder();
+
+    int p1_dist = pf.path_length(state.fences, state.p1, 8);
+    int p2_dist = pf.path_length(state.fences, state.p2, 0);
+
+    if (p1_dist < 0 || p2_dist < 0) {
+        return 0.0f;
+    }
+
+    if (state.is_p1_to_move()) {
+        p1_dist--;
+    } else {
+        p2_dist--;
+    }
+
+    if (p1_dist < p2_dist) {
+        return 1.0f;
+    } else if (p2_dist < p1_dist) {
+        return -1.0f;
+    } else {
+        return state.is_p1_to_move() ? 1.0f : -1.0f;
+    }
+}
+
+/// Perform a random rollout from the given state to terminal or depth limit
+/// Uses early termination when both players out of fences
+/// @param start_node Starting game state
+/// @param max_depth Maximum moves to simulate
+/// @return Terminal value: +1.0 P1 wins, -1.0 P2 wins
+[[nodiscard]] inline float random_rollout(
+    const StateNode& start_node,
+    int max_depth) noexcept
+{
+    thread_local std::mt19937 rng(std::random_device{}());
+
+    // Create lightweight copy for simulation
+    SimState sim(start_node);
+
+    for (int depth = 0; depth < max_depth; ++depth) {
+        // Check terminal
+        int result = sim.game_over();
+        if (result != 0) {
+            return static_cast<float>(result);
+        }
+
+        // Early termination when fences exhausted
+        if (sim.p1.fences == 0 && sim.p2.fences == 0) {
+            return early_terminate_simstate(sim);
+        }
+
+        // Generate valid moves
+        std::vector<Move> moves = sim.generate_valid_moves();
+        if (moves.empty()) {
+            return 0.0f;
+        }
+
+        // Pick random move
+        std::uniform_int_distribution<size_t> dist(0, moves.size() - 1);
+        Move move = moves[dist(rng)];
+
+        // Apply move
+        sim.apply_move(move);
+    }
+
+    // Reached depth limit without terminal - use heuristic
+    return early_terminate_simstate(sim);
+}
+
+/// Evaluate a leaf node using hybrid strategy:
+/// - Random rollout OR neural network, weighted by tree maturity
+/// - More rollout when immature, more NN when mature
+/// @param node Node to evaluate
+/// @param config MCTS configuration
+/// @param root_visits Root node visit count (for maturity estimate)
+/// @param inference Optional NN inference engine
+/// @return Value in [-1, 1] from P1's perspective
+[[nodiscard]] inline float evaluate_leaf(
+    const StateNode& node,
+    const MCTSConfig& config,
+    [[maybe_unused]] uint32_t root_visits,
+    TrainingStats& stats,
+    [[maybe_unused]] void* inference = nullptr) noexcept
+{
+    // Terminal nodes have known values
+    if (node.is_terminal()) {
+        return node.terminal_value;
+    }
+
+    // Early termination when fences exhausted (counts as rollout)
+    if (node.p1.fences == 0 && node.p2.fences == 0) {
+        stats.total_rollouts.fetch_add(1, std::memory_order_relaxed);
+        return early_terminate_no_fences(node);
+    }
+
+#ifdef ENABLE_INFERENCE
+    // Hybrid: choose between rollout and NN based on tree maturity
+    if (inference != nullptr) {
+        auto* model = static_cast<ModelInference*>(inference);
+        if (model->is_ready()) {
+            // P(use_nn) = min(0.9, sqrt(root_visits) / 1000)
+            float p_nn = std::min(0.9f, std::sqrt(static_cast<float>(root_visits)) / 1000.0f);
+
+            thread_local std::mt19937 rng(std::random_device{}());
+            std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+
+            if (dist(rng) < p_nn) {
+                stats.nn_evaluations.fetch_add(1, std::memory_order_relaxed);
+                return model->evaluate_node(&node);
+            }
+        }
+    }
+#endif
+
+    // Default: random rollout
+    stats.total_rollouts.fetch_add(1, std::memory_order_relaxed);
+    return random_rollout(node, config.max_rollout_depth);
+}
+
+// ============================================================================
+// MCTS Engine
+// ============================================================================
+
+/// Parallel MCTS search engine
+///
+/// Manages worker threads that perform MCTS iterations concurrently.
+/// Uses virtual loss for tree parallelism and supports periodic checkpointing.
+class MCTSEngine {
+public:
+    explicit MCTSEngine(MCTSConfig config = MCTSConfig{})
+        : config_(std::move(config)) {}
+
+    ~MCTSEngine() {
+        stop();
+    }
+
+    // Non-copyable, non-movable
+    MCTSEngine(const MCTSEngine&) = delete;
+    MCTSEngine& operator=(const MCTSEngine&) = delete;
+    MCTSEngine(MCTSEngine&&) = delete;
+    MCTSEngine& operator=(MCTSEngine&&) = delete;
+
+    /// Start training workers
+    /// All threads run MCTS iterations from the same root
+    /// @param pool Node pool (must outlive the engine while running)
+    /// @param root_idx Root of the search tree
+    void start_training(NodePool& pool, uint32_t root_idx);
+
+    /// Stop all workers gracefully
+    void stop();
+
+    /// Check if training is running
+    [[nodiscard]] bool is_running() const noexcept {
+        return running_.load(std::memory_order_acquire);
+    }
+
+    /// Get current statistics
+    [[nodiscard]] const TrainingStats& stats() const noexcept { return stats_; }
+
+    /// Get configuration
+    [[nodiscard]] const MCTSConfig& config() const noexcept { return config_; }
+
+    /// Set optional neural network inference engine
+    void set_inference(void* inference) noexcept { inference_ = inference; }
+
+private:
+    /// Single MCTS iteration: select -> expand -> evaluate -> backprop
+    void mcts_iteration(NodePool& pool, uint32_t root_idx);
+
+    /// Backpropagate value up the tree and remove virtual loss
+    void backpropagate(NodePool& pool, const std::vector<uint32_t>& path,
+                       float value) noexcept;
+
+    /// Worker thread main loop
+    void worker_loop(std::stop_token stop_token, int thread_id,
+                     NodePool& pool, uint32_t root_idx);
+
+    /// Checkpoint thread: periodically saves tree
+    void checkpoint_loop(std::stop_token stop_token, NodePool& pool, uint32_t root_idx);
+
+    /// Signal workers to pause for checkpointing
+    void pause_workers();
+
+    /// Resume workers after checkpoint
+    void resume_workers();
+
+    /// Print current statistics
+    void print_stats(const NodePool& pool) const;
+
+    MCTSConfig config_;
+    TrainingStats stats_;
+    void* inference_{nullptr};
+
+    // Threading
+    std::vector<std::jthread> workers_;
+    std::jthread checkpoint_thread_;
+
+    std::atomic<bool> running_{false};
+    std::atomic<bool> paused_{false};
+
+    // Synchronization for checkpointing
+    std::mutex pause_mutex_;
+    std::condition_variable pause_cv_;
+    std::atomic<int> workers_paused_{0};
+
+    // Expansion mutex - prevents multiple threads expanding same node
+    std::mutex expansion_mutex_;
+
+    // Reference to pool and root for checkpointing
+    NodePool* pool_ptr_{nullptr};
+    uint32_t root_idx_{NULL_NODE};
+};
+
+} // namespace qbot

--- a/src/tree/StateNode.cpp
+++ b/src/tree/StateNode.cpp
@@ -305,4 +305,31 @@ size_t StateNode::generate_valid_children(NodePool& pool, uint32_t my_index) noe
     return child_indices.size();
 }
 
+uint32_t StateNode::find_or_create_child(NodePool& pool, uint32_t my_index, Move move) noexcept {
+    // First check if move exists among existing children
+    uint32_t child = first_child;
+    while (child != NULL_NODE) {
+        if (pool[child].move == move) {
+            return child;
+        }
+        child = pool[child].next_sibling;
+    }
+
+    // If not expanded yet, expand and then find the child
+    if (!is_expanded()) {
+        generate_valid_children(pool, my_index);
+    }
+
+    // Now search again
+    child = first_child;
+    while (child != NULL_NODE) {
+        if (pool[child].move == move) {
+            return child;
+        }
+        child = pool[child].next_sibling;
+    }
+
+    return NULL_NODE;
+}
+
 } // namespace qbot

--- a/src/tree/StateNode.cpp
+++ b/src/tree/StateNode.cpp
@@ -351,7 +351,6 @@ uint32_t StateNode::test_and_add_move(Move move) noexcept {
         child = p[child].next_sibling;
     }
 
-    // Validate move is legal
     if (!is_move_valid(move)) {
         return NULL_NODE;
     }

--- a/src/tree/StateNode.h
+++ b/src/tree/StateNode.h
@@ -147,10 +147,10 @@ struct FenceGrid {
         if (c < 7 && has_h_fence(r, c + 1)) return true;
         // Blocked if a vertical fence passes through intersection (r, c)
         if (has_v_fence(r, c)) return true;
-        if (r > 0 && has_v_fence(r - 1, c)) return true;
-        // Blocked if a vertical fence passes through intersection (r, c+1)
-        if (c < 7 && has_v_fence(r, c + 1)) return true;
-        if (r > 0 && c < 7 && has_v_fence(r - 1, c + 1)) return true;
+        // if (r > 0 && has_v_fence(r - 1, c)) return true;
+        // // Blocked if a vertical fence passes through intersection (r, c+1)
+        // if (c < 7 && has_v_fence(r, c + 1)) return true;
+        // if (r > 0 && c < 7 && has_v_fence(r - 1, c + 1)) return true;
         return false;
     }
 
@@ -170,10 +170,10 @@ struct FenceGrid {
         if (r < 7 && has_v_fence(r + 1, c)) return true;
         // Blocked if a horizontal fence passes through intersection (r, c)
         if (has_h_fence(r, c)) return true;
-        if (c > 0 && has_h_fence(r, c - 1)) return true;
-        // Blocked if a horizontal fence passes through intersection (r+1, c)
-        if (r < 7 && has_h_fence(r + 1, c)) return true;
-        if (r < 7 && c > 0 && has_h_fence(r + 1, c - 1)) return true;
+        // if (c > 0 && has_h_fence(r, c - 1)) return true;
+        // // Blocked if a horizontal fence passes through intersection (r+1, c)
+        // if (r < 7 && has_h_fence(r + 1, c)) return true;
+        // if (r < 7 && c > 0 && has_h_fence(r + 1, c - 1)) return true;
         return false;
     }
 

--- a/src/tree/node_pool.h
+++ b/src/tree/node_pool.h
@@ -33,7 +33,7 @@ public:
     /// Configuration for node pool
     struct Config {
         size_t initial_capacity = 10'000'000;  // Initial number of nodes (10M)
-        size_t chunk_size = 1'000'000;         // Nodes per chunk (1M)
+        size_t chunk_size = 10'000'000;        // Nodes per chunk (10M)
         size_t recycle_batch = 1000;           // Nodes to recycle when pool exhausted
         bool enable_lru = true;                // Enable LRU tracking for recycling
     };

--- a/src/util/gui_client.cpp
+++ b/src/util/gui_client.cpp
@@ -158,13 +158,12 @@ std::optional<std::string> GUIClient::receive_json() {
     if (!is_connected()) return std::nullopt;
 
     std::unique_lock<std::mutex> lock(impl_->msg_mutex);
-    bool success = impl_->msg_cv.wait_for(
+    impl_->msg_cv.wait(
         lock,
-        std::chrono::milliseconds(impl_->config.read_timeout_ms),
         [this]() { return !impl_->incoming_messages.empty() || !impl_->connected; }
     );
 
-    if (!success || impl_->incoming_messages.empty()) {
+    if (impl_->incoming_messages.empty()) {
         return std::nullopt;
     }
 
@@ -232,7 +231,7 @@ std::optional<GUIClient::GUIMove> GUIClient::request_move(int player) {
     // Wait for response
     auto response = receive_json();
     if (!response) {
-        last_error_ = "Timeout waiting for move";
+        last_error_ = "Lost connection waiting for move";
         return std::nullopt;
     }
 

--- a/src/util/leopard.cpp
+++ b/src/util/leopard.cpp
@@ -1,7 +1,12 @@
-/// leopard - Tree file to stdout converter for training
+/// leopard - Tree file to training data converter
 ///
-/// Reads a binary tree file and outputs all nodes as raw SerializedNode
-/// structs to stdout for consumption by Python training scripts.
+/// AlphaZero-style training data extraction:
+/// Finds all terminal nodes (completed games) and traces back to root,
+/// outputting each position labeled with the actual game outcome.
+///
+/// Output format: SerializedNode structs where terminal_value contains
+/// the game outcome (z = +1 if P1 won, -1 if P2 won) for ALL nodes,
+/// not just terminal ones.
 
 #include "storage.h"
 #include "../tree/StateNode.h"
@@ -9,13 +14,48 @@
 #include <cstdio>
 #include <deque>
 #include <iostream>
+#include <unordered_set>
+#include <vector>
 
 using namespace qbot;
+
+/// Serialize a node with a specific outcome value
+void output_node(const StateNode& node, float outcome) {
+    SerializedNode serialized;
+    serialized.first_child = node.first_child;
+    serialized.next_sibling = node.next_sibling;
+    serialized.parent = node.parent;
+    serialized.p1_row = node.p1.row;
+    serialized.p1_col = node.p1.col;
+    serialized.p1_fences = node.p1.fences;
+    serialized.p2_row = node.p2.row;
+    serialized.p2_col = node.p2.col;
+    serialized.p2_fences = node.p2.fences;
+    serialized.move_data = node.move.data;
+    serialized.flags = node.flags;
+    serialized.reserved = 0;
+    serialized.ply = node.ply;
+    serialized.fences_horizontal = node.fences.horizontal;
+    serialized.fences_vertical = node.fences.vertical;
+    serialized.visits = node.stats.visits.load(std::memory_order_relaxed);
+    serialized.total_value = node.stats.total_value.load(std::memory_order_relaxed);
+    serialized.prior = node.stats.prior;
+    // Store the GAME OUTCOME, not the node's terminal status
+    serialized.terminal_value = outcome;
+
+    std::fwrite(&serialized, sizeof(SerializedNode), 1, stdout);
+}
 
 int main(int argc, char* argv[]) {
     if (argc != 2) {
         std::cerr << "Usage: leopard <tree_file>\n";
-        std::cerr << "Outputs tree nodes as binary SerializedNode structs to stdout\n";
+        std::cerr << "\n";
+        std::cerr << "Extracts AlphaZero-style training data from a tree file.\n";
+        std::cerr << "Finds completed games (terminal nodes) and outputs all positions\n";
+        std::cerr << "along each game path, labeled with the actual game outcome.\n";
+        std::cerr << "\n";
+        std::cerr << "Output: Binary SerializedNode structs to stdout.\n";
+        std::cerr << "        terminal_value field contains game outcome z ∈ {-1, +1}\n";
         return 1;
     }
 
@@ -33,10 +73,10 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    // Process nodes in breadth-first order
+    // Step 1: Find all terminal nodes via BFS
+    std::vector<uint32_t> terminal_nodes;
     std::deque<uint32_t> queue;
     queue.push_back(root);
-    size_t node_count = 0;
 
     while (!queue.empty()) {
         uint32_t idx = queue.front();
@@ -44,31 +84,9 @@ int main(int argc, char* argv[]) {
 
         const StateNode& node = (*pool)[idx];
 
-        // Serialize the node
-        SerializedNode serialized;
-        serialized.first_child = node.first_child;
-        serialized.next_sibling = node.next_sibling;
-        serialized.parent = node.parent;
-        serialized.p1_row = node.p1.row;
-        serialized.p1_col = node.p1.col;
-        serialized.p1_fences = node.p1.fences;
-        serialized.p2_row = node.p2.row;
-        serialized.p2_col = node.p2.col;
-        serialized.p2_fences = node.p2.fences;
-        serialized.move_data = node.move.data;
-        serialized.flags = node.flags;
-        serialized.reserved = 0;
-        serialized.ply = node.ply;
-        serialized.fences_horizontal = node.fences.horizontal;
-        serialized.fences_vertical = node.fences.vertical;
-        serialized.visits = node.stats.visits.load(std::memory_order_relaxed);
-        serialized.total_value = node.stats.total_value.load(std::memory_order_relaxed);
-        serialized.prior = node.stats.prior;
-        serialized.terminal_value = node.terminal_value;
-
-        // Write raw bytes to stdout
-        std::fwrite(&serialized, sizeof(SerializedNode), 1, stdout);
-        ++node_count;
+        if (node.is_terminal()) {
+            terminal_nodes.push_back(idx);
+        }
 
         // Add children to queue
         uint32_t child = node.first_child;
@@ -78,8 +96,42 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    std::cerr << "Wrote " << node_count << " nodes ("
-              << (node_count * sizeof(SerializedNode)) << " bytes)\n";
+    std::cerr << "Found " << terminal_nodes.size() << " terminal nodes (completed games)\n";
+
+    if (terminal_nodes.empty()) {
+        std::cerr << "No completed games in tree - nothing to output\n";
+        return 0;
+    }
+
+    // Step 2: For each terminal, trace back to root and output training samples
+    // Track which nodes we've already output to avoid duplicates
+    // (same position can be reached via different game paths)
+    std::unordered_set<uint32_t> output_nodes;
+    size_t sample_count = 0;
+    size_t game_count = 0;
+
+    for (uint32_t terminal_idx : terminal_nodes) {
+        const StateNode& terminal = (*pool)[terminal_idx];
+        float outcome = terminal.terminal_value;  // z = +1 (P1 wins) or -1 (P2 wins)
+
+        // Walk back to root
+        uint32_t current = terminal_idx;
+        while (current != NULL_NODE) {
+            // Only output each node once (first game path wins)
+            if (output_nodes.find(current) == output_nodes.end()) {
+                output_node((*pool)[current], outcome);
+                output_nodes.insert(current);
+                ++sample_count;
+            }
+
+            current = (*pool)[current].parent;
+        }
+        ++game_count;
+    }
+
+    std::cerr << "Wrote " << sample_count << " training samples from "
+              << game_count << " games ("
+              << (sample_count * sizeof(SerializedNode)) << " bytes)\n";
 
     return 0;
 }

--- a/src/util/storage.cpp
+++ b/src/util/storage.cpp
@@ -1,63 +1,14 @@
 #include "storage.h"
 
 #include <chrono>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <queue>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace qbot {
-
-namespace {
-
-/// CRC32 lookup table (IEEE polynomial)
-constexpr uint32_t CRC32_TABLE[] = {
-    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
-    0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
-    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
-    0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
-    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
-    0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
-    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
-    0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
-    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
-    0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
-    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
-    0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
-    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
-    0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
-    0x6c0695ed, 0x1b01a57b, 0x8208f4c9, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
-    0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
-    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
-    0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
-    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7a9c, 0x5005713c, 0x270241aa,
-    0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
-    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
-    0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
-    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
-    0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
-    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
-    0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
-    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
-    0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
-    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
-    0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
-    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
-    0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
-    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
-    0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
-    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
-    0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
-    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
-    0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
-    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
-    0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdede86c5, 0x47d7977f, 0x30d0e7e9,
-    0xe9b7f4a0, 0x9eb0e436, 0x07b9b58c, 0x70be851a, 0xeebe9b9, 0x79b80d2f,
-    0xf0b11295, 0x87b62203, 0xfef5b992, 0x89f2c904, 0x10fb5bef, 0x67f66779,
-    0xe1fca5da, 0x96f8954c, 0x0ff17ef6, 0x78f66f60, 0xe8b8d433, 0x9fbfe4a5,
-    0x06b6b51f, 0x71b18589,
-};
-
-} // anonymous namespace
 
 SerializedNode TreeStorage::serialize_node(const StateNode& node) noexcept {
     SerializedNode sn;
@@ -123,59 +74,6 @@ void TreeStorage::deserialize_node(const SerializedNode& src, StateNode& dst) no
     dst.stats.prior = src.prior;
 }
 
-uint32_t TreeStorage::compute_checksum(std::span<const std::byte> data) noexcept {
-    uint32_t crc = 0xFFFFFFFF;
-    for (std::byte b : data) {
-        uint8_t index = static_cast<uint8_t>(crc ^ std::to_integer<uint8_t>(b));
-        crc = CRC32_TABLE[index] ^ (crc >> 8);
-    }
-    return crc ^ 0xFFFFFFFF;
-}
-
-std::vector<uint32_t> TreeStorage::collect_reachable_nodes(
-    const NodePool& pool, uint32_t root)
-{
-    std::vector<uint32_t> result;
-    if (root == NULL_NODE) return result;
-
-    // BFS traversal
-    std::queue<uint32_t> queue;
-    queue.push(root);
-
-    while (!queue.empty()) {
-        uint32_t idx = queue.front();
-        queue.pop();
-
-        result.push_back(idx);
-
-        const StateNode& node = pool[idx];
-
-        // Add all children
-        uint32_t child = node.first_child;
-        while (child != NULL_NODE) {
-            queue.push(child);
-            child = pool[child].next_sibling;
-        }
-    }
-
-    return result;
-}
-
-std::vector<uint32_t> TreeStorage::build_remap_table(
-    const std::vector<uint32_t>& reachable,
-    size_t pool_capacity)
-{
-    // Initialize all entries to NULL_NODE (not remapped)
-    std::vector<uint32_t> remap(pool_capacity, NULL_NODE);
-
-    // Map each reachable node to its new sequential index
-    for (size_t new_idx = 0; new_idx < reachable.size(); ++new_idx) {
-        remap[reachable[new_idx]] = static_cast<uint32_t>(new_idx);
-    }
-
-    return remap;
-}
-
 std::expected<void, StorageError> TreeStorage::save(
     const std::filesystem::path& path,
     const NodePool& pool,
@@ -185,51 +83,81 @@ std::expected<void, StorageError> TreeStorage::save(
         return std::unexpected(StorageError::EmptyTree);
     }
 
-    // Collect all reachable nodes
-    std::vector<uint32_t> reachable = collect_reachable_nodes(pool, root);
+    std::printf("TreeStorage::save - pool.allocated()=%zu, root=%u\n",
+                pool.allocated(), root);
+
+    // Pass 1: BFS to collect reachable nodes and build sparse remap
+    std::vector<uint32_t> reachable;
+    std::unordered_map<uint32_t, uint32_t> remap;  // old_idx -> new_idx
+
+    {
+        std::queue<uint32_t> queue;
+        queue.push(root);
+
+        while (!queue.empty()) {
+            uint32_t idx = queue.front();
+            queue.pop();
+
+            uint32_t new_idx = static_cast<uint32_t>(reachable.size());
+            reachable.push_back(idx);
+            remap[idx] = new_idx;
+
+            const StateNode& node = pool[idx];
+            uint32_t child = node.first_child;
+            while (child != NULL_NODE) {
+                queue.push(child);
+                child = pool[child].next_sibling;
+            }
+        }
+    }
+
     if (reachable.empty()) {
         return std::unexpected(StorageError::EmptyTree);
     }
 
-    // Build index remapping table
-    std::vector<uint32_t> remap = build_remap_table(reachable, pool.capacity());
+    std::printf("TreeStorage::save - BFS found %zu reachable nodes\n", reachable.size());
 
-    // Serialize nodes with remapped indices
-    std::vector<SerializedNode> serialized;
-    serialized.reserve(reachable.size());
+    // Debug: check for orphaned nodes
+    if (reachable.size() < pool.allocated()) {
+        std::unordered_set<uint32_t> reachable_set(reachable.begin(), reachable.end());
+        size_t printed = 0;
+        size_t parent_null = 0;
+        size_t parent_not_reachable = 0;
+        size_t parent_missing_child = 0;
 
-    for (uint32_t old_idx : reachable) {
-        SerializedNode sn = serialize_node(pool[old_idx]);
+        for (size_t i = 0; i < pool.allocated(); ++i) {
+            if (reachable_set.find(static_cast<uint32_t>(i)) == reachable_set.end()) {
+                const StateNode& orphan = pool[static_cast<uint32_t>(i)];
+                uint32_t parent_idx = orphan.parent;
 
-        // Remap indices
-        if (sn.first_child != NULL_NODE) {
-            sn.first_child = remap[sn.first_child];
+                if (parent_idx == NULL_NODE) {
+                    parent_null++;
+                    if (printed < 3) {
+                        std::printf("  Orphan %zu: parent=NULL\n", i);
+                        printed++;
+                    }
+                } else if (reachable_set.find(parent_idx) == reachable_set.end()) {
+                    parent_not_reachable++;
+                    if (printed < 3) {
+                        std::printf("  Orphan %zu: parent=%u (also orphaned)\n", i, parent_idx);
+                        printed++;
+                    }
+                } else {
+                    parent_missing_child++;
+                    if (printed < 3) {
+                        const StateNode& p = pool[parent_idx];
+                        std::printf("  Orphan %zu: parent=%u is reachable, parent.first_child=%u\n",
+                                    i, parent_idx, p.first_child);
+                        printed++;
+                    }
+                }
+            }
         }
-        if (sn.next_sibling != NULL_NODE) {
-            sn.next_sibling = remap[sn.next_sibling];
-        }
-        if (sn.parent != NULL_NODE) {
-            sn.parent = remap[sn.parent];
-        }
-
-        serialized.push_back(sn);
+        std::printf("  Orphan breakdown: parent_null=%zu, parent_orphaned=%zu, parent_missing_link=%zu\n",
+                    parent_null, parent_not_reachable, parent_missing_child);
     }
 
-    // Compute checksum
-    std::span<const std::byte> node_bytes(
-        reinterpret_cast<const std::byte*>(serialized.data()),
-        serialized.size() * sizeof(SerializedNode));
-    uint32_t checksum = compute_checksum(node_bytes);
-
-    // Build header
-    TreeFileHeader header;
-    header.node_count = static_cast<uint32_t>(serialized.size());
-    header.root_index = 0;  // Root is always first after compaction
-    header.checksum = checksum;
-    header.timestamp = static_cast<uint64_t>(
-        std::chrono::system_clock::now().time_since_epoch().count());
-
-    // Write to file
+    // Open file and write header
     std::ofstream file(path, std::ios::binary | std::ios::trunc);
     if (!file) {
         if (!std::filesystem::exists(path.parent_path())) {
@@ -238,15 +166,37 @@ std::expected<void, StorageError> TreeStorage::save(
         return std::unexpected(StorageError::PermissionDenied);
     }
 
+    TreeFileHeader header;
+    header.node_count = static_cast<uint32_t>(reachable.size());
+    header.root_index = 0;  // Root is always first after compaction
+    header.reserved1 = 0;   // No checksum
+    header.timestamp = static_cast<uint64_t>(
+        std::chrono::system_clock::now().time_since_epoch().count());
+
     file.write(reinterpret_cast<const char*>(&header), sizeof(header));
     if (!file) {
         return std::unexpected(StorageError::IoError);
     }
 
-    file.write(reinterpret_cast<const char*>(serialized.data()),
-               static_cast<std::streamsize>(serialized.size() * sizeof(SerializedNode)));
-    if (!file) {
-        return std::unexpected(StorageError::IoError);
+    // Pass 2: Stream nodes directly to file
+    auto remap_index = [&remap](uint32_t idx) -> uint32_t {
+        if (idx == NULL_NODE) return NULL_NODE;
+        auto it = remap.find(idx);
+        return (it != remap.end()) ? it->second : NULL_NODE;
+    };
+
+    for (uint32_t old_idx : reachable) {
+        SerializedNode sn = serialize_node(pool[old_idx]);
+
+        // Remap indices
+        sn.first_child = remap_index(sn.first_child);
+        sn.next_sibling = remap_index(sn.next_sibling);
+        sn.parent = remap_index(sn.parent);
+
+        file.write(reinterpret_cast<const char*>(&sn), sizeof(sn));
+        if (!file) {
+            return std::unexpected(StorageError::IoError);
+        }
     }
 
     file.close();
@@ -287,23 +237,6 @@ std::expected<LoadedTree, StorageError> TreeStorage::load(
         return std::unexpected(StorageError::EmptyTree);
     }
 
-    // Read serialized nodes
-    std::vector<SerializedNode> serialized(header.node_count);
-    file.read(reinterpret_cast<char*>(serialized.data()),
-              static_cast<std::streamsize>(header.node_count * sizeof(SerializedNode)));
-    if (!file) {
-        return std::unexpected(StorageError::IoError);
-    }
-
-    // Verify checksum
-    std::span<const std::byte> node_bytes(
-        reinterpret_cast<const std::byte*>(serialized.data()),
-        serialized.size() * sizeof(SerializedNode));
-    uint32_t computed_checksum = compute_checksum(node_bytes);
-    if (computed_checksum != header.checksum) {
-        return std::unexpected(StorageError::ChecksumMismatch);
-    }
-
     // Create node pool with exact capacity needed
     NodePool::Config config;
     config.initial_capacity = header.node_count;
@@ -315,17 +248,23 @@ std::expected<LoadedTree, StorageError> TreeStorage::load(
         .timestamp = header.timestamp,
     };
 
-    // Allocate and deserialize all nodes
-    for (size_t i = 0; i < serialized.size(); ++i) {
+    // Stream read: read one node at a time directly into pool
+    SerializedNode sn;
+    for (uint32_t i = 0; i < header.node_count; ++i) {
+        file.read(reinterpret_cast<char*>(&sn), sizeof(sn));
+        if (!file) {
+            return std::unexpected(StorageError::IoError);
+        }
+
         uint32_t idx = result.pool->allocate();
         if (idx == NULL_NODE) {
             return std::unexpected(StorageError::InsufficientMemory);
         }
-        // Indices should be sequential since we cleared the pool
-        if (idx != static_cast<uint32_t>(i)) {
+        // Indices should be sequential since pool is fresh
+        if (idx != i) {
             return std::unexpected(StorageError::CorruptedData);
         }
-        deserialize_node(serialized[i], (*result.pool)[idx]);
+        deserialize_node(sn, (*result.pool)[idx]);
     }
 
     return result;

--- a/src/util/storage.cpp
+++ b/src/util/storage.cpp
@@ -306,7 +306,7 @@ std::expected<LoadedTree, StorageError> TreeStorage::load(
 
     // Create node pool with exact capacity needed
     NodePool::Config config;
-    config.capacity = header.node_count;
+    config.initial_capacity = header.node_count;
     config.enable_lru = false;  // Disable LRU for loaded trees initially
 
     LoadedTree result{

--- a/src/util/storage.h
+++ b/src/util/storage.h
@@ -19,7 +19,7 @@ enum class StorageError {
     InvalidFormat,
     VersionMismatch,
     CorruptedData,
-    ChecksumMismatch,
+    ChecksumMismatch,  // Deprecated, no longer used
     InsufficientMemory,
     IoError,
     EmptyTree,
@@ -51,7 +51,7 @@ struct TreeFileHeader {
     uint16_t flags = 0;
     uint32_t node_count = 0;
     uint32_t root_index = NULL_NODE;
-    uint32_t checksum = 0;  // CRC32 of node data
+    uint32_t reserved1 = 0;  // Reserved (was checksum, removed for performance)
     uint64_t timestamp = 0; // Unix timestamp when saved
 
     // Reserved for future use
@@ -140,20 +140,6 @@ private:
 
     /// Convert SerializedNode to StateNode (in-place initialization)
     static void deserialize_node(const SerializedNode& src, StateNode& dst) noexcept;
-
-    /// Compute CRC32 checksum
-    static uint32_t compute_checksum(std::span<const std::byte> data) noexcept;
-
-    /// Collect all reachable nodes from root (BFS traversal)
-    /// Returns indices in the order they should be written
-    static std::vector<uint32_t> collect_reachable_nodes(
-        const NodePool& pool, uint32_t root);
-
-    /// Build index remapping table for compaction
-    /// Maps old indices to new sequential indices
-    static std::vector<uint32_t> build_remap_table(
-        const std::vector<uint32_t>& reachable,
-        size_t pool_capacity);
 };
 
 } // namespace qbot

--- a/tests/test_storage.cpp
+++ b/tests/test_storage.cpp
@@ -279,7 +279,7 @@ TEST(StorageTest, SaveAndLoadDeepTree) {
     TempFile tmp;
 
     NodePool::Config config;
-    config.capacity = 10000;
+    config.initial_capacity = 10000;
     NodePool pool(config);
 
     // Build tree: depth=4, branching=3 => 1 + 3 + 9 + 27 + 81 = 121 nodes
@@ -482,7 +482,7 @@ TEST(StorageTest, LargeTreePerformance) {
 
     // Build a reasonably large tree
     NodePool::Config config;
-    config.capacity = 100000;
+    config.initial_capacity = 100000;
     NodePool pool(config);
 
     // depth=6, branching=4 => 1 + 4 + 16 + 64 + 256 + 1024 + 4096 = 5461 nodes

--- a/tests/test_storage.cpp
+++ b/tests/test_storage.cpp
@@ -350,6 +350,9 @@ TEST(StorageTest, LoadInvalidFile) {
 }
 
 TEST(StorageTest, ChecksumValidation) {
+    // Checksum validation has been removed for performance.
+    // This test now verifies that files load even with corrupted data
+    // (trusting the filesystem for integrity).
     TempFile tmp;
 
     // Create and save a valid tree with some children
@@ -385,13 +388,9 @@ TEST(StorageTest, ChecksumValidation) {
         file.flush();
     }
 
-    // Load should fail with checksum error
+    // Load should succeed now (no checksum validation)
     auto result = TreeStorage::load(tmp.path());
-
-    EXPECT_FALSE(result.has_value());
-    if (!result.has_value()) {
-        EXPECT_EQ(result.error(), StorageError::ChecksumMismatch);
-    }
+    EXPECT_TRUE(result.has_value());
 }
 
 // ============================================================================

--- a/train/StateNode.py
+++ b/train/StateNode.py
@@ -126,12 +126,14 @@ class QuoridorDataset:
         # Wall positions from fence bitmaps
         wall = self._fences_to_wall_tensor(state.fences_horizontal, state.fences_vertical)
 
-        # Meta features (remaining fences)
-        meta = np.array([state.p1_fences, state.p2_fences], dtype=np.float32)
+        # Meta features (remaining fences + turn indicator)
+        # FLAG_P1_TO_MOVE = 0x04
+        is_p1_turn = 1.0 if (state.flags & 0x04) else 0.0
+        meta = np.array([state.p1_fences, state.p2_fences, is_p1_turn], dtype=np.float32)
 
-        # Target value: game outcome z ∈ {-1, +1}
-        # leopard outputs actual game outcomes in terminal_value field
-        # +1 = P1 won, -1 = P2 won
+        # Target value: Q-value from P1's perspective ∈ [-1, +1]
+        # leopard outputs accumulated Q-values in terminal_value field
+        # +1 = P1 winning, -1 = P2 winning
         target = np.array([state.terminal_value], dtype=np.float32)
 
         return (

--- a/train/StateNode.py
+++ b/train/StateNode.py
@@ -129,14 +129,10 @@ class QuoridorDataset:
         # Meta features (remaining fences)
         meta = np.array([state.p1_fences, state.p2_fences], dtype=np.float32)
 
-        # Target value: Q = total_value / visits (mean value)
-        # For terminal nodes, use terminal_value
-        # Normalize to [-1, 1] with tanh
-        if state.visits > 0:
-            q_value = state.total_value / state.visits
-        else:
-            q_value = state.terminal_value if state.terminal_value != 0 else 0.0
-        target = np.array([np.tanh(q_value)], dtype=np.float32)
+        # Target value: game outcome z ∈ {-1, +1}
+        # leopard outputs actual game outcomes in terminal_value field
+        # +1 = P1 won, -1 = P2 won
+        target = np.array([state.terminal_value], dtype=np.float32)
 
         return (
             torch.from_numpy(pawn),

--- a/train/resnet.py
+++ b/train/resnet.py
@@ -69,9 +69,9 @@ class QuoridorValueNet(nn.Module):
             nn.ReLU()
         )
 
-        # Meta features processing (walls remaining)
+        # Meta features processing (walls remaining + turn indicator)
         self.meta_features = nn.Sequential(
-            nn.Linear(2, 8),
+            nn.Linear(3, 8),
             nn.ReLU()
         )
 
@@ -86,7 +86,7 @@ class QuoridorValueNet(nn.Module):
     def forward(self, pawn_state, wall_state, meta_state):
         # pawn_state: batch x 2 x 9 x 9
         # wall_state: batch x 2 x 8 x 8 (horizontal and vertical walls)
-        # meta_state: batch x 2 (walls remaining for each player)
+        # meta_state: batch x 3 (walls remaining for each player + turn indicator)
 
         # Process pawn positions
         x_pawns = self.pawn_conv(pawn_state)
@@ -200,7 +200,7 @@ def main():
             # Create example inputs for tracing
             example_pawn_state = torch.zeros(1, 2, 9, 9)
             example_wall_state = torch.zeros(1, 2, 8, 8)
-            example_meta_state = torch.zeros(1, 2)
+            example_meta_state = torch.zeros(1, 3)
 
             # Use TorchScript to create a serializable version
             traced_script_module = torch.jit.trace(model, (example_pawn_state, example_wall_state, example_meta_state))

--- a/train/train_loop.py
+++ b/train/train_loop.py
@@ -62,7 +62,7 @@ def run_qbot(tree_path: str, model_path: str | None, duration_seconds: int,
 
         # Wait for graceful shutdown (with timeout)
         try:
-            stdout, _ = proc.communicate(timeout=30)
+            stdout, _ = proc.communicate(timeout=60)
             if stdout:
                 # Print last few lines of output
                 lines = stdout.decode().strip().split('\n')

--- a/train/train_loop.py
+++ b/train/train_loop.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+AlphaZero-style training loop for Quoridor.
+
+Alternates between:
+1. Training neural network on completed games in the tree
+2. Building more tree using the trained neural network
+"""
+
+import argparse
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+from resnet import QuoridorValueNet, train
+
+
+def get_project_root():
+    """Get the project root directory."""
+    return Path(__file__).parent.parent
+
+
+def run_qbot(tree_path: str, model_path: str | None, duration_seconds: int,
+             num_threads: int) -> bool:
+    """Run qbot to build tree for a specified duration."""
+    qbot_path = get_project_root() / "build" / "qbot"
+
+    if not qbot_path.exists():
+        logging.error(f"qbot not found at {qbot_path}")
+        return False
+
+    cmd = [
+        str(qbot_path),
+        "-b",  # Training mode
+        "-t", str(num_threads),
+        "-s", tree_path,
+    ]
+
+    # Load existing tree if it exists
+    if os.path.exists(tree_path):
+        cmd.extend(["-l", tree_path])
+
+    # Use model if provided
+    if model_path and os.path.exists(model_path):
+        cmd.extend(["-m", model_path])
+
+    logging.info(f"Running: {' '.join(cmd)}")
+    logging.info(f"Building tree for {duration_seconds} seconds...")
+
+    try:
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        # Wait for duration then send SIGINT for graceful shutdown
+        time.sleep(duration_seconds)
+        proc.send_signal(signal.SIGINT)
+
+        # Wait for graceful shutdown (with timeout)
+        try:
+            stdout, _ = proc.communicate(timeout=30)
+            if stdout:
+                # Print last few lines of output
+                lines = stdout.decode().strip().split('\n')
+                for line in lines[-5:]:
+                    logging.info(f"  {line}")
+        except subprocess.TimeoutExpired:
+            logging.warning("qbot didn't shut down gracefully, killing...")
+            proc.kill()
+            proc.wait()
+
+        return proc.returncode == 0 or proc.returncode == -2  # -2 is SIGINT
+
+    except Exception as e:
+        logging.error(f"Error running qbot: {e}")
+        return False
+
+
+def check_tree_has_games(tree_path: str) -> int:
+    """Check if tree has completed games using leopard. Returns count."""
+    leopard_path = get_project_root() / "build" / "leopard"
+
+    if not leopard_path.exists():
+        logging.error(f"leopard not found at {leopard_path}")
+        return 0
+
+    try:
+        result = subprocess.run(
+            [str(leopard_path), tree_path],
+            capture_output=True,
+            timeout=60
+        )
+
+        # Parse stderr for terminal node count
+        stderr = result.stderr.decode()
+        for line in stderr.split('\n'):
+            if "terminal nodes" in line:
+                # "Found X terminal nodes (completed games)"
+                parts = line.split()
+                if len(parts) >= 2:
+                    return int(parts[1])
+        return 0
+
+    except Exception as e:
+        logging.error(f"Error checking tree: {e}")
+        return 0
+
+
+def train_model(model: QuoridorValueNet, tree_path: str, epochs: int,
+                batch_size: int) -> bool:
+    """Train the model on the current tree."""
+    logging.info(f"Training model for {epochs} epochs...")
+
+    try:
+        train(model, tree_path, batch_size, epochs)
+        return True
+    except Exception as e:
+        logging.error(f"Error training model: {e}")
+        return False
+
+
+def export_model(model: QuoridorValueNet, export_path: str) -> bool:
+    """Export model to TorchScript for C++ inference."""
+    logging.info(f"Exporting model to {export_path}")
+
+    try:
+        model.eval()
+        model.cpu()  # Ensure model is on CPU for export
+
+        # Create example inputs for tracing
+        example_pawn = torch.zeros(1, 2, 9, 9)
+        example_wall = torch.zeros(1, 2, 8, 8)
+        example_meta = torch.zeros(1, 2)
+
+        traced = torch.jit.trace(model, (example_pawn, example_wall, example_meta))
+        traced.save(export_path)
+
+        return True
+    except Exception as e:
+        logging.error(f"Error exporting model: {e}")
+        return False
+
+
+def save_checkpoint(model: QuoridorValueNet, checkpoint_path: str) -> bool:
+    """Save model weights checkpoint."""
+    try:
+        torch.save(model.state_dict(), checkpoint_path)
+        logging.info(f"Saved checkpoint to {checkpoint_path}")
+        return True
+    except Exception as e:
+        logging.error(f"Error saving checkpoint: {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='AlphaZero-style training loop for Quoridor',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    # Paths
+    parser.add_argument('--tree', type=str, default='tree.qbot',
+                        help='Path to tree file')
+    parser.add_argument('--model', type=str, default='model.pt',
+                        help='Path to model weights file')
+    parser.add_argument('--export-model', type=str, default='model_traced.pt',
+                        dest='export_model',
+                        help='Path to exported TorchScript model')
+
+    # Training parameters
+    parser.add_argument('--iterations', type=int, default=10,
+                        help='Number of train/build iterations')
+    parser.add_argument('--tree-time', type=int, default=300, dest='tree_time',
+                        help='Seconds to build tree per iteration')
+    parser.add_argument('--epochs', type=int, default=50,
+                        help='Training epochs per iteration')
+    parser.add_argument('--batch-size', type=int, default=64, dest='batch_size',
+                        help='Training batch size')
+    parser.add_argument('--threads', type=int, default=8,
+                        help='Number of threads for tree building')
+
+    # Options
+    parser.add_argument('--skip-initial-build', action='store_true',
+                        dest='skip_initial_build',
+                        help='Skip initial tree building (use existing tree)')
+    parser.add_argument('--log-level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+                        default='INFO', dest='log_level',
+                        help='Logging level')
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        datefmt='%H:%M:%S'
+    )
+
+    # Initialize model
+    model = QuoridorValueNet()
+
+    # Load existing model if available
+    if os.path.exists(args.model):
+        logging.info(f"Loading existing model from {args.model}")
+        model.load_state_dict(torch.load(args.model))
+
+    # Use GPU if available
+    if torch.cuda.is_available():
+        model.cuda()
+        logging.info("Using CUDA")
+
+    # Resolve paths
+    tree_path = os.path.abspath(args.tree)
+    model_path = os.path.abspath(args.model)
+    export_path = os.path.abspath(args.export_model)
+
+    logging.info("=" * 60)
+    logging.info("Quoridor AlphaZero Training Loop")
+    logging.info("=" * 60)
+    logging.info(f"Tree file:      {tree_path}")
+    logging.info(f"Model file:     {model_path}")
+    logging.info(f"Export file:    {export_path}")
+    logging.info(f"Iterations:     {args.iterations}")
+    logging.info(f"Tree time:      {args.tree_time}s per iteration")
+    logging.info(f"Epochs:         {args.epochs} per iteration")
+    logging.info(f"Threads:        {args.threads}")
+    logging.info("=" * 60)
+
+    for iteration in range(args.iterations):
+        logging.info("")
+        logging.info(f"{'=' * 20} ITERATION {iteration + 1}/{args.iterations} {'=' * 20}")
+
+        # Phase 1: Build tree (skip on first iteration if requested)
+        if iteration == 0 and args.skip_initial_build:
+            logging.info("Skipping initial tree build")
+        else:
+            # Export model for C++ before tree building (if we have trained it)
+            if iteration > 0 or os.path.exists(args.model):
+                if not export_model(model, export_path):
+                    logging.warning("Failed to export model, building without NN")
+                    export_path_for_qbot = None
+                else:
+                    export_path_for_qbot = export_path
+            else:
+                export_path_for_qbot = None
+
+            logging.info(f"[Phase 1] Building tree...")
+            if not run_qbot(tree_path, export_path_for_qbot, args.tree_time, args.threads):
+                logging.error("Tree building failed")
+                continue
+
+        # Check if tree has completed games
+        num_games = check_tree_has_games(tree_path)
+        if num_games == 0:
+            logging.warning("No completed games in tree, skipping training")
+            logging.info("Try running longer or with more depth-first exploration")
+            continue
+
+        logging.info(f"Tree has {num_games} completed games")
+
+        # Phase 2: Train neural network
+        logging.info(f"[Phase 2] Training neural network...")
+        if not train_model(model, tree_path, args.epochs, args.batch_size):
+            logging.error("Training failed")
+            continue
+
+        # Save checkpoint
+        save_checkpoint(model, model_path)
+
+        logging.info(f"Iteration {iteration + 1} complete")
+
+    # Final export
+    logging.info("")
+    logging.info("=" * 60)
+    logging.info("Training complete!")
+    export_model(model, export_path)
+    save_checkpoint(model, model_path)
+    logging.info(f"Final model saved to {model_path}")
+    logging.info(f"TorchScript model saved to {export_path}")
+    logging.info("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/train/train_loop.py
+++ b/train/train_loop.py
@@ -132,9 +132,10 @@ def export_model(model: QuoridorValueNet, export_path: str) -> bool:
         model.cpu()  # Ensure model is on CPU for export
 
         # Create example inputs for tracing
+        # meta has 3 elements: p1_fences, p2_fences, turn_indicator
         example_pawn = torch.zeros(1, 2, 9, 9)
         example_wall = torch.zeros(1, 2, 8, 8)
-        example_meta = torch.zeros(1, 2)
+        example_meta = torch.zeros(1, 3)
 
         traced = torch.jit.trace(model, (example_pawn, example_wall, example_meta))
         traced.save(export_path)
@@ -165,9 +166,9 @@ def main():
     # Paths
     parser.add_argument('--tree', type=str, default='tree.qbot',
                         help='Path to tree file')
-    parser.add_argument('--model', type=str, default='model.pt',
+    parser.add_argument('--model', type=str, default='treestyle.model',
                         help='Path to model weights file')
-    parser.add_argument('--export-model', type=str, default='model_traced.pt',
+    parser.add_argument('--export-model', type=str, default='treestyle.pt',
                         dest='export_model',
                         help='Path to exported TorchScript model')
 


### PR DESCRIPTION
  MCTS tree training infrastructure

  - Add multithreaded MCTS with virtual loss for tree parallelism
  - Chunked NodePool allocation (10M nodes) avoids copies during resize
  - mmap-based tree storage for fast save/load of multi-GB trees
  - Vector remapping replaces hash map for O(1) index lookups
  - Striped mutex for concurrent backpropagation
  - Add test_and_add_move for incremental child generation
  - Training loop with checkpointing and memory limits
  - Leopard tool for dumping trees to training data
  - Python train_loop.py for neural network training
