### PR TITLE
True alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ core.*
 tree*.out
 tree.qbot
 samples/
+log/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 model/
 core.*
 tree*.out
+tree*.qsamples
 tree.qbot
 samples/
 log/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ model/
 core.*
 tree*.out
 tree.qbot
+samples/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__
 model/
 core.*
 tree*.out
+tree.qbot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,10 @@ train/
   train_loop.py          # AlphaZero loop: run_selfplay → train_model → run_arena → promote/reject
 
 tests/
-  test_state.cpp
-  test_mcts.cpp
-  test_tree.cpp
+  test_game.cpp         # Unit tests for Game, tree building, terminal detection
+  test_storage.cpp      # Unit tests for binary tree serialization
+  test_inference.cpp    # Unit tests for NN inference (requires ENABLE_INFERENCE)
+  benchmarks.cpp        # Performance benchmarks (not run by ctest): ./benchmarks
 ```
 
 ## Old Code
@@ -134,6 +135,9 @@ Assume we are already in the conda env "qenv" which should allow us to compile a
 - Random game sequences always terminate
 - Wall blocking never creates unreachable goals
 - Visit counts monotonically increase
+
+### Benchmarks
+Run `./benchmarks` from the build directory to measure performance (e.g., `./benchmarks --gtest_filter="GameBenchmark.BuildTree"`).
 
 ## Build System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,22 +81,28 @@ For bounded memory scenarios:
 ```
 src/
   core/
-    types.h          # Move, Position, Player types
-    Game.h           # Game state (no tree logic)
-    Game.cpp
+    Game.h/cpp           # Game controller: manages tree, GUI connection, move selection
+    QuoridorMain.cpp     # CLI entry point with boost::program_options, run modes (interactive/train/selfplay/arena)
   tree/
-    Node.h           # TreeNode with edge statistics
-    node_pool.h      # Memory-bounded node allocation
-    Tree.h           # MCTS tree operations
-    Tree.cpp
+    StateNode.h/cpp      # Core game state node with Move, Player, FenceGrid structs, EdgeStats atomics, PUCT selection
+    node_pool.h          # Chunked lock-free node pool with CAS allocation, LRU tracking, auto-growth
   search/
-    mcts.h           # MCTS algorithm
-    mcts.cpp
-    selection.h      # UCB/PUCT selection policies
-    evaluation.h     # Rollout and NN evaluation interface
-  ipc/
-    protocol.h       # UI communication protocol
-    protocol.cpp
+    mcts.h/cpp           # Parallel MCTS engine: virtual loss, memory bounds, SelfPlayEngine, MCTSEngine classes
+  inference/
+    inference.h/cpp      # TorchScript model wrapper: state→tensor conversion, batched GPU inference
+    inference_server.h/cpp # Async inference server: thread-safe queue, batches requests for GPU efficiency
+  util/
+    pathfinding.h/cpp    # A* pathfinder for fence validation (ensures no player gets blocked)
+    gui_client.h/cpp     # WebSocket client for standalone GUI (JSON protocol)
+    storage.h/cpp        # Binary tree serialization: TreeFileHeader, SerializedNode, save/load/prune
+    timer.h              # ScopedTimer and TimerAccumulator for profiling self-play performance
+    leopard.cpp          # CLI tool that streams SerializedNodes to stdout for Python training
+
+train/
+  resnet.py              # QuoridorValueNet: dual-tower ResNet (pawn + wall features) → value head
+  StateNode.py           # QuoridorDataset: reads binary tree via leopard subprocess, yields PyTorch batches
+  train_loop.py          # AlphaZero loop: run_selfplay → train_model → run_arena → promote/reject
+
 tests/
   test_state.cpp
   test_mcts.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,10 +196,19 @@ if(BUILD_TESTS)
     target_link_options(test_game PRIVATE -flto)
 
     if(ENABLE_INFERENCE)
+        # Regular inference tests - debug build for ctest
         add_executable(test_inference tests/test_inference.cpp)
-        target_link_libraries(test_inference PRIVATE qbot_lib_fast GTest::gtest_main)
-        target_compile_options(test_inference PRIVATE -O3 -DNDEBUG -march=native -flto)
-        target_link_options(test_inference PRIVATE -flto)
+        target_link_libraries(test_inference PRIVATE qbot_lib_debug GTest::gtest_main)
+        target_compile_options(test_inference PRIVATE -g -O0)
+
+        # Inference benchmarks - optimized build, NOT registered with ctest
+        add_executable(bench_inference tests/bench_inference.cpp)
+        target_link_libraries(bench_inference PRIVATE qbot_lib_fast GTest::gtest_main)
+        target_compile_options(bench_inference PRIVATE -O3 -DNDEBUG -march=native -flto)
+        target_link_options(bench_inference PRIVATE -flto)
+        set_target_properties(bench_inference PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
     endif()
 
     # Debug test builds
@@ -224,13 +233,20 @@ if(BUILD_TESTS)
         gtest_discover_tests(test_inference)
     endif()
 
-    # "tests" target - builds all test binaries
+    # "tests" target - builds all test binaries (excludes benchmarks)
     set(TEST_TARGETS test_storage test_game)
     if(ENABLE_INFERENCE)
         list(APPEND TEST_TARGETS test_inference)
     endif()
 
     add_custom_target(tests DEPENDS ${TEST_TARGETS})
+
+    # "benchmarks" target - builds benchmark binaries (optimized, not run by ctest)
+    if(ENABLE_INFERENCE)
+        add_custom_target(benchmarks DEPENDS bench_inference
+            COMMENT "Building optimized benchmark binaries (run directly, not via ctest)"
+        )
+    endif()
 endif()
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ set(QBOT_LIB_SOURCES
 )
 
 if(ENABLE_INFERENCE)
-    list(APPEND QBOT_LIB_SOURCES src/inference/inference.cpp)
+    list(APPEND QBOT_LIB_SOURCES
+        src/inference/inference.cpp
+        src/inference/inference_server.cpp)
 endif()
 
 set(QBOT_MAIN_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(QBOT_LIB_SOURCES
     src/tree/StateNode.cpp
     src/util/storage.cpp
     src/util/gui_client.cpp
+    src/util/training_samples.cpp
     src/core/Game.cpp
     src/util/pathfinding.cpp
     src/search/mcts.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,35 +196,21 @@ if(BUILD_TESTS)
     target_link_options(test_game PRIVATE -flto)
 
     if(ENABLE_INFERENCE)
-        # Regular inference tests - debug build for ctest
         add_executable(test_inference tests/test_inference.cpp)
-        target_link_libraries(test_inference PRIVATE qbot_lib_debug GTest::gtest_main)
-        target_compile_options(test_inference PRIVATE -g -O0)
-
-        # Inference benchmarks - optimized build, NOT registered with ctest
-        add_executable(bench_inference tests/bench_inference.cpp)
-        target_link_libraries(bench_inference PRIVATE qbot_lib_fast GTest::gtest_main)
-        target_compile_options(bench_inference PRIVATE -O3 -DNDEBUG -march=native -flto)
-        target_link_options(bench_inference PRIVATE -flto)
-        set_target_properties(bench_inference PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
-        )
+        target_link_libraries(test_inference PRIVATE qbot_lib_fast GTest::gtest_main)
+        target_compile_options(test_inference PRIVATE -O3 -DNDEBUG -march=native -flto)
+        target_link_options(test_inference PRIVATE -flto)
     endif()
 
-    # Debug test builds
-    add_executable(test_storage_debug tests/test_storage.cpp)
-    target_link_libraries(test_storage_debug PRIVATE qbot_lib_debug GTest::gtest_main)
-    target_compile_options(test_storage_debug PRIVATE -g -O0)
-
-    add_executable(test_game_debug tests/test_game.cpp)
-    target_link_libraries(test_game_debug PRIVATE qbot_lib_debug GTest::gtest_main)
-    target_compile_options(test_game_debug PRIVATE -g -O0)
-
-    if(ENABLE_INFERENCE)
-        add_executable(test_inference_debug tests/test_inference.cpp)
-        target_link_libraries(test_inference_debug PRIVATE qbot_lib_debug GTest::gtest_main)
-        target_compile_options(test_inference_debug PRIVATE -g -O0)
-    endif()
+    # Benchmarks - optimized build, NOT registered with ctest
+    # Game benchmarks always available; inference benchmarks require ENABLE_INFERENCE
+    add_executable(benchmarks tests/benchmarks.cpp)
+    target_link_libraries(benchmarks PRIVATE qbot_lib_fast GTest::gtest_main)
+    target_compile_options(benchmarks PRIVATE -O3 -DNDEBUG -march=native -flto)
+    target_link_options(benchmarks PRIVATE -flto)
+    set_target_properties(benchmarks PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
 
     include(GoogleTest)
     gtest_discover_tests(test_storage)
@@ -241,12 +227,6 @@ if(BUILD_TESTS)
 
     add_custom_target(tests DEPENDS ${TEST_TARGETS})
 
-    # "benchmarks" target - builds benchmark binaries (optimized, not run by ctest)
-    if(ENABLE_INFERENCE)
-        add_custom_target(benchmarks DEPENDS bench_inference
-            COMMENT "Building optimized benchmark binaries (run directly, not via ctest)"
-        )
-    endif()
 endif()
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ ctest -R Inference   # InferenceTest.* (requires ENABLE_INFERENCE)
 ./test_inference     # requires ENABLE_INFERENCE
 
 # Useful specific tests (verbose output when run alone)
-./test_game --gtest_filter=GameTest.BenchmarkBuildTree
 ./test_game --gtest_filter=GameTest.BuildTreeUntilWinAndPrintPath
 ```
 
@@ -50,23 +49,23 @@ ctest -R Inference   # InferenceTest.* (requires ENABLE_INFERENCE)
 Benchmarks are built with full optimizations (`-O3 -march=native -flto`) and are **not** registered with CTest (won't run during `ctest`). This ensures accurate performance measurements.
 
 ```bash
-# Build benchmarks (requires ENABLE_INFERENCE)
+# Build benchmarks
 make benchmarks
 
-# Run all inference benchmarks
-./bench_inference
+# Run all benchmarks
+./benchmarks
 
 # Run specific benchmarks
-./bench_inference --gtest_filter="InferenceBenchmark.BatchSizes"
-./bench_inference --gtest_filter="InferenceBenchmark.QueueLatency"
+./benchmarks --gtest_filter="GameBenchmark.BuildTree"
+./benchmarks --gtest_filter="InferenceBenchmark.BatchSizes"
 ```
 
 **Available benchmarks:**
 
 | Benchmark | Description |
 |-----------|-------------|
-| `BatchSizes` | Measures inference throughput at batch sizes 1-512, reports per-node latency and throughput |
-| `QueueLatency` | Measures end-to-end latency from queue submission to result callback at various internal batch sizes |
+| `GameBenchmark.BuildTree` | Measures tree building throughput (nodes/sec) over 3 seconds |
+| `InferenceBenchmark.BatchSizes` | Measures NN inference throughput at batch sizes 1-512 (requires ENABLE_INFERENCE) |
 
 ## GUI Visualization
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ cmake ..
 make              # Debug build (qbot)
 make fast         # Optimized build (-O3 -march=native -flto)
 make leopard      # Tree file dumper for training
-make test_game    # Build game tests
-make test_storage # Build storage tests
+make tests        # Build all unit tests (debug)
+make benchmarks   # Build benchmarks (optimized) - requires ENABLE_INFERENCE
 ```
 
 With neural network inference (requires libtorch):
@@ -19,19 +19,54 @@ cmake .. -DENABLE_INFERENCE=ON
 make
 ```
 
-## Run Tests
+## Testing
+
+Unit tests are built with debug flags (`-g -O0`) and registered with CTest.
 
 ```bash
-# All tests
+# Run all tests via CTest
+ctest
+
+# Run with verbose output
+ctest -V
+
+# Run specific test suites
+ctest -R Game        # GameTest.*
+ctest -R Storage     # StorageTest.*
+ctest -R Inference   # InferenceTest.* (requires ENABLE_INFERENCE)
+
+# Run tests directly with GoogleTest (more control)
 ./test_game
 ./test_storage
+./test_inference     # requires ENABLE_INFERENCE
 
 # Useful specific tests (verbose output when run alone)
-# builds a tree for 3 seconds and prints how many nodes it created
 ./test_game --gtest_filter=GameTest.BenchmarkBuildTree
-# builds tree at random with low branching factor until someone wins, then prints whole game path.
 ./test_game --gtest_filter=GameTest.BuildTreeUntilWinAndPrintPath
 ```
+
+## Benchmarks
+
+Benchmarks are built with full optimizations (`-O3 -march=native -flto`) and are **not** registered with CTest (won't run during `ctest`). This ensures accurate performance measurements.
+
+```bash
+# Build benchmarks (requires ENABLE_INFERENCE)
+make benchmarks
+
+# Run all inference benchmarks
+./bench_inference
+
+# Run specific benchmarks
+./bench_inference --gtest_filter="InferenceBenchmark.BatchSizes"
+./bench_inference --gtest_filter="InferenceBenchmark.QueueLatency"
+```
+
+**Available benchmarks:**
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BatchSizes` | Measures inference throughput at batch sizes 1-512, reports per-node latency and throughput |
+| `QueueLatency` | Measures end-to-end latency from queue submission to result callback at various internal batch sizes |
 
 ## GUI Visualization
 

--- a/gui/SAMPLES_VIEWER.md
+++ b/gui/SAMPLES_VIEWER.md
@@ -1,0 +1,65 @@
+# Training Samples Viewer
+
+The GUI now includes a training samples viewer mode that allows you to browse through `.qsamples` files and inspect the training data.
+
+## Usage
+
+```bash
+cd gui
+python main.py --samples path/to/file.qsamples
+```
+
+For example:
+```bash
+python main.py --samples ../samples/tree_0.qsamples
+```
+
+## Features
+
+### Display
+- Shows the board state for each training sample
+- Displays player positions and fence counts
+- Renders all walls on the board
+- Shows the evaluation score (value) for the current player
+- Indicates whose turn it is
+
+### Navigation
+- **Left Arrow / A**: Previous sample
+- **Right Arrow / D**: Next sample
+- **Home**: Jump to first sample
+- **End**: Jump to last sample
+- **Page Up**: Jump back 10 samples
+- **Page Down**: Jump forward 10 samples
+- **Q / Escape**: Quit viewer
+
+### Stats Display (Terminal)
+For each sample, the terminal displays:
+- Sample number and total count
+- Current player (P1 or P2)
+- Value (from current player's perspective)
+- Player positions (x, y) and fence counts
+- Number of horizontal and vertical walls
+- **Top 10 policy moves** with probabilities:
+  - Move type (pawn, h_wall, v_wall)
+  - Position (x, y)
+  - Probability percentage
+
+## What is a .qsamples file?
+
+`.qsamples` files contain pre-computed training samples from self-play games. Each sample includes:
+- **Board state**: Player positions, walls, fence counts
+- **Policy target**: MCTS visit distribution (what moves were explored)
+- **Value target**: Game outcome from current player's perspective
+
+These files are generated during self-play (with the `--selfplay` flag in qbot) and are used for training the neural network.
+
+## Implementation Details
+
+The viewer directly parses the binary `.qsamples` format:
+- Header (64 bytes): Magic number, version, sample count
+- Samples (864 bytes each):
+  - CompactState (24 bytes): Positions, fences, flags
+  - Policy (836 bytes): 209 floats for action probabilities
+  - Value (4 bytes): Game outcome
+
+The state is always stored from the current player's perspective, which the viewer correctly interprets using the flags field to determine whose turn it is.

--- a/gui/main.py
+++ b/gui/main.py
@@ -296,9 +296,15 @@ def main():
     parser = argparse.ArgumentParser(description="Quoridor GUI with WebSocket server")
     parser.add_argument("--host", default="localhost", help="Host to bind to (default: localhost)")
     parser.add_argument("--port", type=int, default=8765, help="Port to listen on (default: 8765)")
+    parser.add_argument("--samples", type=str, help="View training samples from .qsamples file")
     args = parser.parse_args()
 
-    asyncio.run(main_async(args.host, args.port))
+    # If --samples flag is provided, run samples viewer instead
+    if args.samples:
+        from samples_viewer import main as samples_main
+        samples_main(args.samples)
+    else:
+        asyncio.run(main_async(args.host, args.port))
 
 
 if __name__ == "__main__":

--- a/gui/samples_viewer.py
+++ b/gui/samples_viewer.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+Samples viewer for Quoridor training data.
+
+Loads .qsamples files and allows browsing through training samples,
+displaying the board state and statistics.
+"""
+import os
+import sys
+import struct
+import numpy as np
+import pygame
+from typing import List, Tuple
+from pathlib import Path
+
+# Action space constants (must match C++ and Python)
+NUM_PAWN_ACTIONS = 81   # 9x9 board destinations
+NUM_WALL_ACTIONS = 128  # 8x8 * 2 orientations
+NUM_ACTIONS = NUM_PAWN_ACTIONS + NUM_WALL_ACTIONS  # 209 total
+
+from window import Window
+from player import Players
+from wall import Walls
+from colors import Colors
+from protocol import GameState, PlayerState, WallState
+
+
+class Sample:
+    """Parsed training sample."""
+    def __init__(self, state_tensor, policy, value):
+        self.state_tensor = state_tensor  # (6, 9, 9) numpy array
+        self.policy = policy              # (209,) numpy array
+        self.value = value                # float
+
+        # These will be set by the loader
+        self.p1_row = 0
+        self.p1_col = 0
+        self.p2_row = 0
+        self.p2_col = 0
+        self.p1_fences = 0
+        self.p2_fences = 0
+        self.current_player = 0
+
+        # These will be set from the raw data
+        self.h_walls = []
+        self.v_walls = []
+
+    def _extract_walls(self, channel: np.ndarray) -> List[Tuple[int, int]]:
+        """Extract wall positions from channel."""
+        walls = []
+        for r in range(8):
+            for c in range(8):
+                if channel[r, c] == 1.0:
+                    walls.append((c, r))
+        return walls
+
+    def to_gamestate(self) -> GameState:
+        """Convert sample to GameState for GUI rendering."""
+        # Positions are already in protocol format (y=0 is top)
+        # GUI expects y=0 at top, y=8 at bottom, which matches protocol
+        players = [
+            PlayerState(x=self.p1_col, y=self.p1_row, walls=self.p1_fences, name="P1"),
+            PlayerState(x=self.p2_col, y=self.p2_row, walls=self.p2_fences, name="P2")
+        ]
+
+        walls = []
+        for x, y in self.h_walls:
+            walls.append(WallState(x=x, y=7-y, orientation="h"))
+        for x, y in self.v_walls:
+            walls.append(WallState(x=x, y=7-y, orientation="v"))
+
+        return GameState(
+            players=players,
+            walls=walls,
+            current_player=self.current_player,
+            score=self.value,
+            winner=None
+        )
+
+    def get_top_policy_moves(self, k=10) -> List[Tuple[str, int, int, float]]:
+        """Get top k moves by policy value."""
+        # Get indices sorted by policy value (descending)
+        top_indices = np.argsort(self.policy)[::-1][:k]
+
+        moves = []
+        for idx in top_indices:
+            prob = self.policy[idx]
+            if prob < 0.001:  # Skip very low probability moves
+                continue
+
+            if idx < NUM_PAWN_ACTIONS:
+                # Pawn move: row * 9 + col
+                row = idx // 9
+                col = idx % 9
+                moves.append(("pawn", col, row, prob))
+            else:
+                # Wall move
+                wall_idx = idx - NUM_PAWN_ACTIONS
+                if wall_idx < 64:
+                    # Horizontal wall
+                    row = wall_idx // 8
+                    col = wall_idx % 8
+                    moves.append(("h_wall", col, row, prob))
+                else:
+                    # Vertical wall
+                    wall_idx -= 64
+                    row = wall_idx // 8
+                    col = wall_idx % 8
+                    moves.append(("v_wall", col, row, prob))
+
+        return moves
+
+
+def load_samples_direct(samples_path: str) -> List[Sample]:
+    """Load all samples from a .qsamples file by reading the raw binary."""
+    print(f"Loading samples from {samples_path}...")
+    samples = []
+
+    # Read header
+    with open(samples_path, 'rb') as f:
+        header_data = f.read(64)
+        magic, version, flags, sample_count = struct.unpack('<IHHI', header_data[:12])
+
+        print(f"File info: magic={hex(magic)}, version={version}, samples={sample_count}")
+
+        # Read each sample (24 + 836 + 4 = 864 bytes each)
+        for i in range(sample_count):
+            sample_data = f.read(864)
+            if len(sample_data) < 864:
+                break
+
+            # Parse CompactState (24 bytes)
+            p1_row, p1_col, p2_row, p2_col = struct.unpack('BBBB', sample_data[0:4])
+            p1_fences, p2_fences = struct.unpack('BB', sample_data[4:6])
+            sample_flags = sample_data[6]
+            fences_h, fences_v = struct.unpack('<QQ', sample_data[8:24])
+
+            # Parse policy (209 floats = 836 bytes)
+            policy = np.frombuffer(sample_data[24:24+209*4], dtype=np.float32).copy()
+
+            # Parse value (1 float = 4 bytes)
+            value = struct.unpack('<f', sample_data[24+209*4:24+209*4+4])[0]
+
+            # Build state tensor from compact state
+            state_tensor = np.zeros((6, 9, 9), dtype=np.float32)
+
+            # FLAG_P1_TO_MOVE = 0x04
+            is_p1_turn = (sample_flags & 0x04) != 0
+
+            # Determine current player and opponent
+            if is_p1_turn:
+                my_row, my_col, my_fences = p1_row, p1_col, p1_fences
+                opp_row, opp_col, opp_fences = p2_row, p2_col, p2_fences
+                current_player = 0
+            else:
+                my_row, my_col, my_fences = p2_row, p2_col, p2_fences
+                opp_row, opp_col, opp_fences = p1_row, p1_col, p1_fences
+                current_player = 1
+
+            # Channel 0: Current player's pawn
+            state_tensor[0, my_row, my_col] = 1.0
+
+            # Channel 1: Opponent's pawn
+            state_tensor[1, opp_row, opp_col] = 1.0
+
+            # Channel 2: Horizontal walls
+            for r in range(8):
+                for c in range(8):
+                    if (fences_h >> (r * 8 + c)) & 1:
+                        state_tensor[2, r, c] = 1.0
+
+            # Channel 3: Vertical walls
+            for r in range(8):
+                for c in range(8):
+                    if (fences_v >> (r * 8 + c)) & 1:
+                        state_tensor[3, r, c] = 1.0
+
+            # Channel 4: Current player's fences
+            state_tensor[4, :, :] = my_fences / 10.0
+
+            # Channel 5: Opponent's fences
+            state_tensor[5, :, :] = opp_fences / 10.0
+
+            sample = Sample(state_tensor, policy, value)
+            sample.current_player = current_player  # Override with correct value
+            sample.p1_row, sample.p1_col = p1_row, p1_col
+            sample.p2_row, sample.p2_col = p2_row, p2_col
+            sample.p1_fences, sample.p2_fences = p1_fences, p2_fences
+
+            # Extract walls from tensor
+            sample.h_walls = sample._extract_walls(state_tensor[2])
+            sample.v_walls = sample._extract_walls(state_tensor[3])
+
+            samples.append(sample)
+
+    print(f"Loaded {len(samples)} samples")
+    return samples
+
+
+class SamplesViewer:
+    """GUI for viewing training samples."""
+
+    def __init__(self, samples: List[Sample]):
+        pygame.init()
+        self.clock = pygame.time.Clock()
+        self.win = Window()
+        self.coords = self.win.coords
+        self.players = Players(2, self.coords)
+        self.walls = Walls()
+        self.samples = samples
+        self.current_index = 0
+        self.running = True
+
+        # Display first sample
+        self.update_display()
+
+    def update_display(self):
+        """Update GUI to show current sample."""
+        if not self.samples:
+            return
+
+        sample = self.samples[self.current_index]
+        gs = sample.to_gamestate()
+
+        # Print stats to terminal
+        print("\n" + "=" * 80)
+        print(f"Sample {self.current_index + 1}/{len(self.samples)}")
+        print("=" * 80)
+        print(f"Current player: P{sample.current_player + 1}")
+        print(f"Value: {sample.value:.4f} (from current player's perspective)")
+        print(f"P1 position: ({sample.p1_col}, {sample.p1_row}), fences: {sample.p1_fences}")
+        print(f"P2 position: ({sample.p2_col}, {sample.p2_row}), fences: {sample.p2_fences}")
+        print(f"Horizontal walls: {len(sample.h_walls)}")
+        print(f"Vertical walls: {len(sample.v_walls)}")
+        print()
+        print("Top 10 policy moves:")
+        for i, (move_type, x, y, prob) in enumerate(sample.get_top_policy_moves(10), 1):
+            print(f"  {i}. {move_type:8s} at ({x}, {y}): {prob:.4f} ({prob*100:.2f}%)")
+        print("=" * 80)
+        print("Navigation: Left/Right arrows (or A/D), Home/End, PgUp/PgDn, Q to quit")
+
+        # Reset GUI state
+        self.coords.reset()
+        for i, ps in enumerate(gs.players):
+            p = self.players.players[i]
+            gui_y = 8 - ps.y
+            p.coord = self.coords.find_coord(ps.x, gui_y)
+            p.coord.is_occuped = True
+            p.walls_remain = ps.walls
+            p.set_name(ps.name)
+
+        self.walls.reset()
+        for ws in gs.walls:
+            gui_y = 7 - ws.y
+            c1 = self.coords.find_coord(ws.x, gui_y)
+            c1.link_coord()
+
+            if ws.orientation == "h":
+                c2 = self.coords.find_coord(ws.x, gui_y + 1)
+            else:
+                c2 = self.coords.find_coord(ws.x + 1, gui_y)
+
+            c2.link_coord()
+            from wall import Wall
+            w = Wall(c1, c2, self.win)
+            w.set_color(Colors.black)
+            self.walls.add_wall(w)
+
+        # Update info text
+        self.win.update_info(f"Sample {self.current_index + 1}/{len(self.samples)} - "
+                           f"Use arrow keys to navigate, Q to quit")
+
+    def handle_input(self):
+        """Handle keyboard input for navigation."""
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self.running = False
+
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_q or event.key == pygame.K_ESCAPE:
+                    self.running = False
+
+                elif event.key == pygame.K_LEFT or event.key == pygame.K_a:
+                    # Previous sample
+                    if self.current_index > 0:
+                        self.current_index -= 1
+                        self.update_display()
+
+                elif event.key == pygame.K_RIGHT or event.key == pygame.K_d:
+                    # Next sample
+                    if self.current_index < len(self.samples) - 1:
+                        self.current_index += 1
+                        self.update_display()
+
+                elif event.key == pygame.K_HOME:
+                    # First sample
+                    self.current_index = 0
+                    self.update_display()
+
+                elif event.key == pygame.K_END:
+                    # Last sample
+                    self.current_index = len(self.samples) - 1
+                    self.update_display()
+
+                elif event.key == pygame.K_PAGEUP:
+                    # Jump back 10 samples
+                    self.current_index = max(0, self.current_index - 10)
+                    self.update_display()
+
+                elif event.key == pygame.K_PAGEDOWN:
+                    # Jump forward 10 samples
+                    self.current_index = min(len(self.samples) - 1, self.current_index + 10)
+                    self.update_display()
+
+    def render(self):
+        """Render current sample."""
+        pos = pygame.mouse.get_pos()
+        sample = self.samples[self.current_index]
+        self.win.redraw_window(self.players, self.walls, pos,
+                              score=sample.value, current_player=sample.current_player)
+
+    def run(self):
+        """Main viewer loop."""
+        while self.running:
+            self.clock.tick(40)
+            self.handle_input()
+            self.render()
+
+        pygame.quit()
+
+
+def main(samples_path: str):
+    """Entry point for samples viewer."""
+    samples = load_samples_direct(samples_path)
+
+    if not samples:
+        print("No samples loaded!")
+        return
+
+    viewer = SamplesViewer(samples)
+    viewer.run()

--- a/src/core/Game.cpp
+++ b/src/core/Game.cpp
@@ -206,7 +206,8 @@ Move Game::select_best_move(uint32_t node_idx) {
         uint32_t child_idx = current.first_child;
         while (child_idx != NULL_NODE) {
             StateNode& child = (*pool_)[child_idx];
-            float score = model_->evaluate_node(&child);
+            auto result = model_->evaluate_node(&child);
+            float score = result.value;
 
             bool dominated = maximize ? (score > best_score) : (score < best_score);
             if (dominated) {

--- a/src/core/QuoridorMain.cpp
+++ b/src/core/QuoridorMain.cpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <cmath>
 #include <filesystem>
 #include <iostream>
 #include <optional>
@@ -773,7 +774,9 @@ int run_arena(const Config& config) {
     std::cout << "  Candidate wins: " << candidate_wins << "\n";
     std::cout << "  Current wins:   " << current_wins << "\n";
     std::cout << "  Draws:          " << draws << "\n";
-    // std::cout << "  Draw Score:     " << draw_score << "\n";
+    if (!std::isnan(draw_score)) {
+        std::cout << "  Draw Score:     " << draw_score << "\n";
+    }
     std::cout << "  Errors:         " << errors << "\n";
     std::cout << "  Win rate:       " << std::fixed << std::setprecision(1)
               << (candidate_win_rate * 100) << "%\n";
@@ -933,7 +936,9 @@ int run_selfplay(const Config& config,
         std::cout << "  P1 wins:\t" << p1_wins << " (" << (100.0 * p1_wins / config.num_games) << "%)\n";
         std::cout << "  P2 wins:\t" << p2_wins << " (" << (100.0 * p2_wins / config.num_games) << "%)\n";
         std::cout << "  Draws:\t" << draws << "\n";
-		// std::cout << "  Draw Score:\t" << avg_draw_score << "\n";
+        if (!std::isnan(draw_score)) {
+            std::cout << "  Draw Score:     " << avg_draw_score << "\n";
+        }
 		std::cout << "  Errors:\t" << errors << "\n";
         std::cout << "  moves/game:\t" << (total_moves / config.num_games) << "\n";
         std::cout << "  Samples:\t" << collector.size() << "\n";

--- a/src/core/QuoridorMain.cpp
+++ b/src/core/QuoridorMain.cpp
@@ -132,7 +132,7 @@ std::optional<Config> Config::from_args(int argc, char* argv[]) {
             "Ply to drop temperature to 0")
         ("progressive", po::bool_switch(&config.progressive),
             "Use progressive expansion (on-demand child creation)")
-        ("max-memory", po::value<size_t>(&config.max_memory_gb)->default_value(40),
+        ("max-memory", po::value<size_t>(&config.max_memory_gb)->default_value(35),
             "Max memory for node pool in GB (resets pool at 80%)");
 
     po::variables_map vm;

--- a/src/core/QuoridorMain.cpp
+++ b/src/core/QuoridorMain.cpp
@@ -756,8 +756,8 @@ int run_arena(const Config& config) {
 		? static_cast<float>(draw_score) / draws
 		: 0.0f;
 	bool promote_candidate = candidate_win_rate >= config.win_threshold;
-	//Draw conditions, if no one won a single game, do avg draw score > 1.5 moves
-	float draw_promo_thresh = 1.5; //decided arbitrarily
+	//Draw conditions, if no one won a single game, do likelihood of draw win > 60%, ie .2 in [-1,1]
+	float draw_promo_thresh = .2;
     if (candidate_wins == 0 && current_wins == 0) {
 		promote_candidate = avg_draw_score >= draw_promo_thresh;
 	}
@@ -768,7 +768,7 @@ int run_arena(const Config& config) {
     std::cout << "  Candidate wins: " << candidate_wins << "\n";
     std::cout << "  Current wins:   " << current_wins << "\n";
     std::cout << "  Draws:          " << draws << "\n";
-    std::cout << "  Draw Score:     " << draw_score << "\n";
+    // std::cout << "  Draw Score:     " << draw_score << "\n";
     std::cout << "  Errors:         " << errors << "\n";
     std::cout << "  Win rate:       " << std::fixed << std::setprecision(1)
               << (candidate_win_rate * 100) << "%\n";
@@ -881,7 +881,7 @@ int run_selfplay(const Config& config,
             std::cout << "[" << completed << "/" << config.num_games << "] "
                       << "P1: " << p1 << ", P2: " << p2 << ", Draw: " << d
                       << " | Nodes: " << p.allocated()
-                      << " | Avg moves: " << (completed > 0 ? moves / completed : 0) << "\n";
+                      << " | Avg moves: " << (completed > 0 ? moves / completed : 0) << std::endl;
         };
 
         MultiGameStats stats;
@@ -923,12 +923,12 @@ int run_selfplay(const Config& config,
         std::cout << "  P1 wins:\t" << p1_wins << " (" << (100.0 * p1_wins / config.num_games) << "%)\n";
         std::cout << "  P2 wins:\t" << p2_wins << " (" << (100.0 * p2_wins / config.num_games) << "%)\n";
         std::cout << "  Draws:\t" << draws << "\n";
-		std::cout << "  Draw Score:\t" << avg_draw_score << "\n";
+		// std::cout << "  Draw Score:\t" << avg_draw_score << "\n";
 		std::cout << "  Errors:\t" << errors << "\n";
         std::cout << "  moves/game:\t" << (total_moves / config.num_games) << "\n";
         std::cout << "  Samples:\t" << collector.size() << "\n";
         std::cout << "  Avg batch sz: " << std::fixed << std::setprecision(1) << avg_batch_size
-                  << " (" << total_requests << " requests / " << total_batches << " batches)\n";
+                  << " (" << total_requests << " requests / " << total_batches << " batches)" << std::endl;
 
     } else {
         // Single-threaded path (original implementation)
@@ -962,7 +962,7 @@ int run_selfplay(const Config& config,
                           << " | Nodes: " << pool->allocated()
                           << " | Samples: " << collector.size()
                           << " | Avg moves: " << (total_moves / (game + 1))
-                          << " | " << std::fixed << std::setprecision(1) << games_per_sec << " g/s\n";
+                          << " | " << std::fixed << std::setprecision(1) << games_per_sec << " g/s"<< std::endl;
             }
 
             if ((game + 1) % config.games_per_checkpoint == 0 && !config.save_file.empty()) {
@@ -979,7 +979,7 @@ int run_selfplay(const Config& config,
         std::cout << "  P1 wins: " << p1_wins << " (" << (100.0 * p1_wins / config.num_games) << "%)\n";
         std::cout << "  P2 wins: " << p2_wins << " (" << (100.0 * p2_wins / config.num_games) << "%)\n";
         std::cout << "  Draws:   " << draws << "\n";
-        std::cout << "  Avg moves per game: " << (total_moves / config.num_games) << "\n";
+        std::cout << "  Avg moves per game: " << (total_moves / config.num_games) << std::endl;
     }
 
     // Save training samples

--- a/src/inference/inference.cpp
+++ b/src/inference/inference.cpp
@@ -1,5 +1,6 @@
 #include "inference.h"
 #include "../tree/StateNode.h"
+#include "../util/timer.h"
 
 #include <iostream>
 
@@ -127,58 +128,44 @@ void ModelInference::process_batch(const EvalCallback& callback) {
 }
 
 float ModelInference::evaluate_node(const StateNode* node) {
-    auto [pawn, wall, meta] = state_to_tensors(node);
+    // Reuse batch path for consistency and to benefit from same optimizations
+    // Single-node eval is inherently slow on GPU due to poor utilization
+    auto options = torch::TensorOptions().dtype(torch::kFloat32).pinned_memory(device_.is_cuda());
+    auto batch_pawn = torch::zeros({1, 2, 9, 9}, options);
+    auto batch_wall = torch::zeros({1, 2, 8, 8}, options);
+    auto batch_meta = torch::zeros({1, 3}, options);
 
-    // Add batch dimension and move to device
-    pawn = pawn.unsqueeze(0).to(device_);
-    wall = wall.unsqueeze(0).to(device_);
-    meta = meta.unsqueeze(0).to(device_);
+    // Fill directly via accessors
+    auto pawn_acc = batch_pawn.accessor<float, 4>();
+    auto wall_acc = batch_wall.accessor<float, 4>();
+    auto meta_acc = batch_meta.accessor<float, 2>();
 
-    // Run inference
-    std::vector<torch::jit::IValue> inputs;
-    inputs.push_back(pawn);
-    inputs.push_back(wall);
-    inputs.push_back(meta);
+    pawn_acc[0][0][node->p1.row][node->p1.col] = 1.0f;
+    pawn_acc[0][1][node->p2.row][node->p2.col] = 1.0f;
 
-    torch::NoGradGuard no_grad;
-    auto output = model_.forward(inputs).toTensor();
-
-    float value = output.to(torch::kCPU).item<float>();
-
-    if (std::isnan(value)) {
-        value = 0.0f;
+    const FenceGrid& fences = node->fences;
+    for (int r = 0; r < 8; ++r) {
+        for (int c = 0; c < 8; ++c) {
+            if (fences.has_h_fence(r, c)) {
+                wall_acc[0][0][r][c] = 1.0f;
+            }
+            if (fences.has_v_fence(r, c)) {
+                wall_acc[0][1][r][c] = 1.0f;
+            }
+        }
     }
 
-    return value;
-}
+    meta_acc[0][0] = static_cast<float>(node->p1.fences);
+    meta_acc[0][1] = static_cast<float>(node->p2.fences);
+    meta_acc[0][2] = node->is_p1_to_move() ? 1.0f : 0.0f;
 
-std::vector<float> ModelInference::evaluate_batch(const std::vector<const StateNode*>& nodes) {
-    std::vector<float> results;
-    if (nodes.empty()) return results;
+    // Move to device
+    batch_pawn = batch_pawn.to(device_, /*non_blocking=*/true);
+    batch_wall = batch_wall.to(device_, /*non_blocking=*/true);
+    batch_meta = batch_meta.to(device_, /*non_blocking=*/true);
 
-    const int batch_size = static_cast<int>(nodes.size());
-    results.reserve(batch_size);
-
-    // Prepare batch tensors
-    auto batch_pawn = torch::zeros({batch_size, 2, 9, 9}, torch::kFloat32);
-    auto batch_wall = torch::zeros({batch_size, 2, 8, 8}, torch::kFloat32);
-    auto batch_meta = torch::zeros({batch_size, 3}, torch::kFloat32);
-
-    // Fill batch tensors
-    for (int i = 0; i < batch_size; ++i) {
-        auto [pawn, wall, meta] = state_to_tensors(nodes[i]);
-        batch_pawn[i] = pawn;
-        batch_wall[i] = wall;
-        batch_meta[i] = meta;
-    }
-
-    // Move tensors to device
-    batch_pawn = batch_pawn.to(device_);
-    batch_wall = batch_wall.to(device_);
-    batch_meta = batch_meta.to(device_);
-
-    // Run inference
     std::vector<torch::jit::IValue> inputs;
+    inputs.reserve(3);
     inputs.push_back(batch_pawn);
     inputs.push_back(batch_wall);
     inputs.push_back(batch_meta);
@@ -186,16 +173,121 @@ std::vector<float> ModelInference::evaluate_batch(const std::vector<const StateN
     torch::NoGradGuard no_grad;
     auto output = model_.forward(inputs).toTensor();
 
-    // Move output back to CPU
-    output = output.to(torch::kCPU);
+    float value = output.to(torch::kCPU).data_ptr<float>()[0];
+    return std::isnan(value) ? 0.0f : value;
+}
 
-    // Extract values
-    for (int i = 0; i < batch_size; ++i) {
-        float value = output[i].item<float>();
-        if (std::isnan(value)) {
-            value = 0.0f;
+void ModelInference::ensure_buffer_capacity(int size) {
+    if (size <= buffer_capacity_) return;
+
+    // Round up to power of 2 for efficiency
+    int new_capacity = 256;
+    while (new_capacity < size) new_capacity *= 2;
+
+    auto options = torch::TensorOptions().dtype(torch::kFloat32).pinned_memory(device_.is_cuda());
+    pawn_buffer_ = torch::zeros({new_capacity, 2, 9, 9}, options);
+    wall_buffer_ = torch::zeros({new_capacity, 2, 8, 8}, options);
+    meta_buffer_ = torch::zeros({new_capacity, 3}, options);
+    buffer_capacity_ = new_capacity;
+}
+
+std::vector<float> ModelInference::evaluate_batch(const std::vector<const StateNode*>& nodes) {
+    auto& timers = get_timers();
+    std::vector<float> results;
+    if (nodes.empty()) return results;
+
+    const int batch_size = static_cast<int>(nodes.size());
+    results.resize(batch_size);
+
+    // Ensure we have enough buffer space
+    {
+        ScopedTimer t(timers.tensor_alloc);
+        ensure_buffer_capacity(batch_size);
+    }
+
+    // Zero and fill only the portion we need
+    {
+        ScopedTimer t(timers.tensor_fill);
+
+        // Get raw pointers for fast zeroing and filling
+        float* pawn_ptr = pawn_buffer_.data_ptr<float>();
+        float* wall_ptr = wall_buffer_.data_ptr<float>();
+        float* meta_ptr = meta_buffer_.data_ptr<float>();
+
+        // Zero the buffers for this batch (only the part we'll use)
+        const size_t pawn_stride = 2 * 9 * 9;
+        const size_t wall_stride = 2 * 8 * 8;
+        const size_t meta_stride = 3;
+
+        std::memset(pawn_ptr, 0, batch_size * pawn_stride * sizeof(float));
+        std::memset(wall_ptr, 0, batch_size * wall_stride * sizeof(float));
+        std::memset(meta_ptr, 0, batch_size * meta_stride * sizeof(float));
+
+        // Fill the tensors
+        for (int i = 0; i < batch_size; ++i) {
+            const StateNode* node = nodes[i];
+
+            // Pawn positions: buffer[i][channel][row][col]
+            // Index = i * (2*9*9) + channel * (9*9) + row * 9 + col
+            float* pawn_base = pawn_ptr + i * pawn_stride;
+            pawn_base[0 * 81 + node->p1.row * 9 + node->p1.col] = 1.0f;  // P1
+            pawn_base[1 * 81 + node->p2.row * 9 + node->p2.col] = 1.0f;  // P2
+
+            // Wall positions: buffer[i][channel][row][col]
+            float* wall_base = wall_ptr + i * wall_stride;
+            const FenceGrid& fences = node->fences;
+            for (int r = 0; r < 8; ++r) {
+                for (int c = 0; c < 8; ++c) {
+                    if (fences.has_h_fence(r, c)) {
+                        wall_base[0 * 64 + r * 8 + c] = 1.0f;
+                    }
+                    if (fences.has_v_fence(r, c)) {
+                        wall_base[1 * 64 + r * 8 + c] = 1.0f;
+                    }
+                }
+            }
+
+            // Meta: [p1_fences, p2_fences, is_p1_turn]
+            float* meta_base = meta_ptr + i * meta_stride;
+            meta_base[0] = static_cast<float>(node->p1.fences);
+            meta_base[1] = static_cast<float>(node->p2.fences);
+            meta_base[2] = node->is_p1_to_move() ? 1.0f : 0.0f;
         }
-        results.push_back(value);
+    }
+
+    // Slice buffers to actual batch size and move to GPU
+    torch::Tensor batch_pawn, batch_wall, batch_meta;
+    {
+        ScopedTimer t(timers.tensor_to_gpu);
+        batch_pawn = pawn_buffer_.slice(0, 0, batch_size).to(device_, /*non_blocking=*/true);
+        batch_wall = wall_buffer_.slice(0, 0, batch_size).to(device_, /*non_blocking=*/true);
+        batch_meta = meta_buffer_.slice(0, 0, batch_size).to(device_, /*non_blocking=*/true);
+    }
+
+    // Run inference
+    torch::Tensor output;
+    {
+        ScopedTimer t(timers.model_forward);
+        std::vector<torch::jit::IValue> inputs;
+        inputs.reserve(3);
+        inputs.push_back(batch_pawn);
+        inputs.push_back(batch_wall);
+        inputs.push_back(batch_meta);
+
+        torch::NoGradGuard no_grad;
+        output = model_.forward(inputs).toTensor();
+    }
+
+    // Move output to CPU
+    {
+        ScopedTimer t(timers.tensor_to_cpu);
+        output = output.to(torch::kCPU).contiguous();
+    }
+
+    const float* output_ptr = output.data_ptr<float>();
+    for (int i = 0; i < batch_size; ++i) {
+        float value = output_ptr[i];
+        results[i] = std::isnan(value) ? 0.0f : value;
     }
 
     return results;

--- a/src/inference/inference.h
+++ b/src/inference/inference.h
@@ -14,21 +14,60 @@ namespace qbot {
 // Forward declaration
 struct StateNode;
 
+/// Action space constants (must match Python resnet.py)
+/// Action encoding:
+///   0-80:    pawn move to square (row * 9 + col)
+///   81-144:  horizontal wall at (row * 8 + col)
+///   145-208: vertical wall at (row * 8 + col)
+inline constexpr int NUM_PAWN_ACTIONS = 81;   // 9x9 board destinations
+inline constexpr int NUM_H_WALL_ACTIONS = 64; // 8x8 horizontal walls
+inline constexpr int NUM_V_WALL_ACTIONS = 64; // 8x8 vertical walls
+inline constexpr int NUM_WALL_ACTIONS = NUM_H_WALL_ACTIONS + NUM_V_WALL_ACTIONS;  // 128 total
+inline constexpr int NUM_ACTIONS = NUM_PAWN_ACTIONS + NUM_WALL_ACTIONS;  // 209 total
+
+// Forward declaration for Move (defined in StateNode.h)
+struct Move;
+
+/// Convert a Move to action index for the policy head
+/// Pawn moves: row * 9 + col (indices 0-80)
+/// Horizontal walls: 81 + row * 8 + col (indices 81-144)
+/// Vertical walls: 145 + row * 8 + col (indices 145-208)
+/// Returns -1 for invalid moves
+[[nodiscard]] int move_to_action_index(const Move& move) noexcept;
+
+/// Convert an action index to a Move
+/// Returns an invalid Move if index is out of range
+[[nodiscard]] Move action_index_to_move(int action_index) noexcept;
+
+/// Result of neural network evaluation
+struct EvalResult {
+    float value;                              // Position value from current player's perspective
+    std::array<float, NUM_ACTIONS> policy;    // Policy logits for all actions
+};
+
 /// Neural network inference for position evaluation
 ///
 /// Converts game states to tensor representation and runs batched inference
 /// using a TorchScript model. Supports both immediate single-node evaluation
 /// and queued batch processing for efficiency.
 ///
-/// Tensor format:
-///   - pawn_tensor: [2, 9, 9] - one-hot encoded player positions
-///   - wall_tensor: [2, 8, 8] - horizontal and vertical fence placements
-///   - meta_tensor: [2] - remaining fence counts for each player
+/// Input tensor format (current-player-perspective):
+///   - unified tensor: [6, 9, 9]
+///     [0] Current player's pawn position (one-hot)
+///     [1] Opponent's pawn position (one-hot)
+///     [2] Horizontal walls (padded 8x8 -> 9x9)
+///     [3] Vertical walls (padded 8x8 -> 9x9)
+///     [4] Current player's fences remaining / 10 (constant plane)
+///     [5] Opponent's fences remaining / 10 (constant plane)
+///
+/// Output format:
+///   - policy_logits: [209] raw logits for all actions
+///   - value: scalar in [-1, 1] from current player's perspective
 class ModelInference {
 public:
     /// Callback type for async batch processing
-    /// Called with (node_index, value) for each evaluated node
-    using EvalCallback = std::function<void(uint32_t, float)>;
+    /// Called with (node_index, value, policy) for each evaluated node
+    using EvalCallback = std::function<void(uint32_t, const EvalResult&)>;
 
     /// Construct inference engine with a TorchScript model
     /// @param model_path Path to the .pt TorchScript model file
@@ -48,19 +87,22 @@ public:
     void queue_for_evaluation(const StateNode* node, uint32_t node_idx);
 
     /// Process any remaining nodes in the queue
-    /// @param callback Called for each evaluated node with (index, value)
+    /// @param callback Called for each evaluated node with (index, result)
     void flush_queue(const EvalCallback& callback);
 
     /// Evaluate a single node immediately (bypasses queue)
     /// @param node Node to evaluate
-    /// @return Model's value estimate for the position
-    [[nodiscard]] float evaluate_node(const StateNode* node);
+    /// @return Model's evaluation result (value and policy)
+    [[nodiscard]] EvalResult evaluate_node(const StateNode* node);
 
     /// Evaluate multiple nodes in a batch (for efficient GPU utilization)
     /// Used for computing priors: evaluate all children at once
     /// @param nodes Vector of node pointers to evaluate
-    /// @return Vector of value estimates, one per node
-    [[nodiscard]] std::vector<float> evaluate_batch(const std::vector<const StateNode*>& nodes);
+    /// @return Vector of evaluation results, one per node
+    [[nodiscard]] std::vector<EvalResult> evaluate_batch(const std::vector<const StateNode*>& nodes);
+
+    /// Evaluate and return only values (legacy interface, ignores policy)
+    [[nodiscard]] std::vector<float> evaluate_batch_values(const std::vector<const StateNode*>& nodes);
 
     /// Get current queue size
     [[nodiscard]] size_t queue_size() const noexcept { return evaluation_queue_.size(); }
@@ -69,10 +111,10 @@ public:
     static void print_diagnostics();
 
 private:
-    /// Convert a StateNode to tensor inputs
-    /// @return Tuple of (pawn_tensor[2,9,9], wall_tensor[2,8,8], meta_tensor[2])
-    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
-    state_to_tensors(const StateNode* node) const;
+    /// Fill unified tensor for a single node at the given batch index
+    /// Handles current-player-perspective transformation
+    void fill_unified_tensor(float* tensor_ptr, size_t tensor_stride,
+                             int batch_idx, const StateNode* node) const;
 
     /// Process a batch of queued nodes
     /// @param callback Called for each evaluated node
@@ -88,14 +130,12 @@ private:
 
     /// Queue entries: (node pointer, node index)
     std::deque<std::pair<const StateNode*, uint32_t>> evaluation_queue_;
-    std::vector<torch::jit::IValue> inputs_internal_; 
 
     /// Pre-allocated tensor buffers (CPU pinned memory for fast GPU transfer)
     int buffer_capacity_{0};
-    torch::Tensor pawn_buffer_;   // [capacity, 2, 9, 9]
-    torch::Tensor wall_buffer_;   // [capacity, 2, 8, 8]
-    torch::Tensor meta_buffer_;   // [capacity, 3]
-    torch::Tensor output_buffer_; // [capacity] - pinned CPU buffer for GPU->CPU transfer
+    torch::Tensor unified_buffer_;      // [capacity, 6, 9, 9]
+    torch::Tensor value_output_buffer_; // [capacity] - pinned CPU buffer for GPU->CPU transfer
+    torch::Tensor policy_output_buffer_; // [capacity, NUM_ACTIONS] - policy outputs
 };
 
 } // namespace qbot

--- a/src/inference/inference.h
+++ b/src/inference/inference.h
@@ -78,6 +78,9 @@ private:
     /// @param callback Called for each evaluated node
     void process_batch(const EvalCallback& callback);
 
+    /// Ensure pre-allocated buffers can hold at least `size` nodes
+    void ensure_buffer_capacity(int size);
+
     torch::jit::script::Module model_;
     torch::Device device_;
     int batch_size_;
@@ -85,6 +88,12 @@ private:
 
     /// Queue entries: (node pointer, node index)
     std::deque<std::pair<const StateNode*, uint32_t>> evaluation_queue_;
+
+    /// Pre-allocated tensor buffers (CPU pinned memory for fast GPU transfer)
+    int buffer_capacity_{0};
+    torch::Tensor pawn_buffer_;   // [capacity, 2, 9, 9]
+    torch::Tensor wall_buffer_;   // [capacity, 2, 8, 8]
+    torch::Tensor meta_buffer_;   // [capacity, 3]
 };
 
 } // namespace qbot

--- a/src/inference/inference.h
+++ b/src/inference/inference.h
@@ -56,6 +56,12 @@ public:
     /// @return Model's value estimate for the position
     [[nodiscard]] float evaluate_node(const StateNode* node);
 
+    /// Evaluate multiple nodes in a batch (for efficient GPU utilization)
+    /// Used for computing priors: evaluate all children at once
+    /// @param nodes Vector of node pointers to evaluate
+    /// @return Vector of value estimates, one per node
+    [[nodiscard]] std::vector<float> evaluate_batch(const std::vector<const StateNode*>& nodes);
+
     /// Get current queue size
     [[nodiscard]] size_t queue_size() const noexcept { return evaluation_queue_.size(); }
 

--- a/src/inference/inference.h
+++ b/src/inference/inference.h
@@ -88,12 +88,14 @@ private:
 
     /// Queue entries: (node pointer, node index)
     std::deque<std::pair<const StateNode*, uint32_t>> evaluation_queue_;
+    std::vector<torch::jit::IValue> inputs_internal_; 
 
     /// Pre-allocated tensor buffers (CPU pinned memory for fast GPU transfer)
     int buffer_capacity_{0};
     torch::Tensor pawn_buffer_;   // [capacity, 2, 9, 9]
     torch::Tensor wall_buffer_;   // [capacity, 2, 8, 8]
     torch::Tensor meta_buffer_;   // [capacity, 3]
+    torch::Tensor output_buffer_; // [capacity] - pinned CPU buffer for GPU->CPU transfer
 };
 
 } // namespace qbot

--- a/src/inference/inference_server.cpp
+++ b/src/inference/inference_server.cpp
@@ -1,0 +1,184 @@
+#include "inference_server.h"
+
+#include <chrono>
+#include <iostream>
+
+namespace qbot {
+
+InferenceServer::InferenceServer(const std::string& model_path,
+                                 InferenceServerConfig config)
+    : model_(model_path, config.batch_size, true)
+    , config_(config)
+{}
+
+InferenceServer::~InferenceServer() {
+    stop();
+}
+
+void InferenceServer::start() {
+    if (running_.exchange(true, std::memory_order_acq_rel)) {
+        return;  // Already running
+    }
+
+    stop_requested_.store(false, std::memory_order_release);
+    inference_thread_ = std::thread([this] { inference_loop(); });
+
+    std::cout << "[InferenceServer] Started with batch_size=" << config_.batch_size
+              << ", max_wait=" << config_.max_wait_ms << "ms\n";
+}
+
+void InferenceServer::stop() {
+    if (!running_.load(std::memory_order_acquire)) {
+        return;  // Not running
+    }
+
+    // Signal stop
+    stop_requested_.store(true, std::memory_order_release);
+
+    // Wake up inference thread
+    queue_cv_.notify_all();
+
+    // Wait for thread to finish
+    if (inference_thread_.joinable()) {
+        inference_thread_.join();
+    }
+
+    running_.store(false, std::memory_order_release);
+
+    std::cout << "[InferenceServer] Stopped. Total requests: " << total_requests_.load()
+              << ", batches: " << total_batches_.load() << "\n";
+}
+
+std::future<float> InferenceServer::submit(const StateNode* node) {
+    std::promise<float> promise;
+    auto future = promise.get_future();
+
+    {
+        std::lock_guard lock(queue_mutex_);
+        single_queue_.push_back({node, std::move(promise)});
+    }
+
+    total_requests_.fetch_add(1, std::memory_order_relaxed);
+    queue_cv_.notify_one();
+
+    return future;
+}
+
+std::future<std::vector<float>> InferenceServer::submit_batch(
+    std::vector<const StateNode*> nodes)
+{
+    std::promise<std::vector<float>> promise;
+    auto future = promise.get_future();
+
+    size_t count = nodes.size();
+
+    {
+        std::lock_guard lock(queue_mutex_);
+        batch_queue_.push_back({std::move(nodes), std::move(promise)});
+    }
+
+    total_requests_.fetch_add(count, std::memory_order_relaxed);
+    queue_cv_.notify_one();
+
+    return future;
+}
+
+void InferenceServer::inference_loop() {
+    auto& timers = get_timers();
+
+    while (!stop_requested_.load(std::memory_order_acquire)) {
+        // Wait for requests or timeout
+        {
+            std::unique_lock lock(queue_mutex_);
+
+            // Wait until we have requests or stop is requested
+            auto deadline = std::chrono::steady_clock::now() +
+                           std::chrono::microseconds(static_cast<long long>(config_.max_wait_ms*1000));
+
+            queue_cv_.wait_until(lock, deadline, [this] {
+                return !single_queue_.empty() ||
+                       !batch_queue_.empty() ||
+                       stop_requested_.load(std::memory_order_acquire);
+            });
+        }
+
+        // Process pending requests
+        process_pending();
+    }
+
+    // Process any remaining requests before exiting
+    process_pending();
+}
+
+void InferenceServer::process_pending() {
+    auto& timers = get_timers();
+
+    // Collect all pending requests
+    std::vector<EvalRequest> singles;
+    std::vector<BatchEvalRequest> batches;
+
+    {
+        std::lock_guard lock(queue_mutex_);
+
+        // Take all single requests (up to batch size)
+        while (!single_queue_.empty() &&
+               singles.size() < static_cast<size_t>(config_.batch_size)) {
+            singles.push_back(std::move(single_queue_.front()));
+            single_queue_.pop_front();
+        }
+
+        // Take all batch requests
+        while (!batch_queue_.empty()) {
+            batches.push_back(std::move(batch_queue_.front()));
+            batch_queue_.pop_front();
+        }
+    }
+
+    // Combine singles and batches into one mega-batch for better GPU utilization
+    std::vector<const StateNode*> all_nodes;
+    size_t singles_count = 0;
+
+    if (!singles.empty()) {
+        singles_count = singles.size();
+        all_nodes.reserve(singles.size() + batches.size() * 100);  // estimate
+        for (const auto& req : singles) {
+            all_nodes.push_back(req.node);
+        }
+    }
+
+    // Track where each batch's results start
+    std::vector<size_t> batch_offsets;
+    for (auto& batch_req : batches) {
+        batch_offsets.push_back(all_nodes.size());
+        for (const auto* node : batch_req.nodes) {
+            all_nodes.push_back(node);
+        }
+    }
+
+    if (all_nodes.empty()) return;
+
+    // Single GPU call for everything
+    std::vector<float> all_values;
+    {
+        ScopedTimer t(timers.nn_batch_eval);
+        all_values = model_.evaluate_batch(all_nodes);
+    }
+
+    // Distribute results to singles
+    for (size_t i = 0; i < singles_count; ++i) {
+        singles[i].promise.set_value(all_values[i]);
+    }
+
+    // Distribute results to batches
+    for (size_t b = 0; b < batches.size(); ++b) {
+        size_t start = batch_offsets[b];
+        size_t count = batches[b].nodes.size();
+        std::vector<float> batch_values(all_values.begin() + start,
+                                         all_values.begin() + start + count);
+        batches[b].promise.set_value(std::move(batch_values));
+    }
+
+    total_batches_.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace qbot

--- a/src/inference/inference_server.h
+++ b/src/inference/inference_server.h
@@ -1,0 +1,128 @@
+#pragma once
+
+/// Async Inference Server for Multi-Threaded Self-Play
+///
+/// Provides a thread-safe interface for GPU inference:
+/// - Worker threads submit evaluation requests
+/// - Dedicated inference thread batches requests and runs GPU inference
+/// - Results returned via futures for async/await pattern
+///
+/// This amortizes GPU kernel launch overhead across many requests and
+/// allows CPU threads to do useful work while waiting for results.
+
+#include "inference.h"
+#include "../tree/StateNode.h"
+#include "../util/timer.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace qbot {
+
+/// Single evaluation request
+struct EvalRequest {
+    const StateNode* node;
+    std::promise<float> promise;
+};
+
+/// Batch evaluation request (for computing priors on children)
+struct BatchEvalRequest {
+    std::vector<const StateNode*> nodes;
+    std::promise<std::vector<float>> promise;
+};
+
+/// Configuration for inference server
+struct InferenceServerConfig {
+    int batch_size = 128;           // Target batch size before processing
+    double max_wait_ms = 1.0;            // Max time to wait for batch to fill
+    bool enable_batching = true;    // If false, process requests immediately
+};
+
+/// Thread-safe inference server
+///
+/// Usage:
+///   InferenceServer server(model_path);
+///   server.start();
+///
+///   // From worker threads:
+///   auto future = server.submit(node);
+///   float value = future.get();  // Blocks until result ready
+///
+///   server.stop();
+class InferenceServer {
+public:
+    /// Construct server with model path
+    InferenceServer(const std::string& model_path,
+                    InferenceServerConfig config = InferenceServerConfig{});
+
+    ~InferenceServer();
+
+    // Non-copyable, non-movable
+    InferenceServer(const InferenceServer&) = delete;
+    InferenceServer& operator=(const InferenceServer&) = delete;
+
+    /// Start the inference thread
+    void start();
+
+    /// Stop the inference thread (processes remaining requests first)
+    void stop();
+
+    /// Check if server is running
+    [[nodiscard]] bool is_running() const noexcept {
+        return running_.load(std::memory_order_acquire);
+    }
+
+    /// Submit a single node for evaluation
+    /// Returns a future that will contain the value estimate
+    [[nodiscard]] std::future<float> submit(const StateNode* node);
+
+    /// Submit a batch of nodes for evaluation (e.g., all children for priors)
+    /// Returns a future that will contain all value estimates
+    [[nodiscard]] std::future<std::vector<float>> submit_batch(
+        std::vector<const StateNode*> nodes);
+
+    /// Get statistics
+    [[nodiscard]] size_t total_requests() const noexcept {
+        return total_requests_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] size_t total_batches() const noexcept {
+        return total_batches_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] size_t current_queue_size() const noexcept {
+        std::lock_guard lock(queue_mutex_);
+        return single_queue_.size() + batch_queue_.size();
+    }
+
+private:
+    /// Main loop for inference thread
+    void inference_loop();
+
+    /// Process all pending requests
+    void process_pending();
+
+    ModelInference model_;
+    InferenceServerConfig config_;
+
+    // Inference thread
+    std::thread inference_thread_;
+    std::atomic<bool> running_{false};
+    std::atomic<bool> stop_requested_{false};
+
+    // Request queues (protected by queue_mutex_)
+    mutable std::mutex queue_mutex_;
+    std::condition_variable queue_cv_;
+    std::deque<EvalRequest> single_queue_;
+    std::deque<BatchEvalRequest> batch_queue_;
+
+    // Statistics
+    std::atomic<size_t> total_requests_{0};
+    std::atomic<size_t> total_batches_{0};
+};
+
+} // namespace qbot

--- a/src/search/mcts.cpp
+++ b/src/search/mcts.cpp
@@ -310,6 +310,7 @@ SelfPlayResult SelfPlayEngine::self_play(NodePool& pool, uint32_t root_idx, Mode
 
     uint32_t current = root_idx;
     game_path.push_back(current);
+    pool[current].set_on_game_path();
 
     while (current != NULL_NODE) {
         StateNode& node = pool[current];
@@ -393,6 +394,7 @@ SelfPlayResult SelfPlayEngine::self_play(NodePool& pool, uint32_t root_idx, Mode
 
         current = next;
         game_path.push_back(current);
+        pool[current].set_on_game_path();
         result.num_moves++;
 
         // Safety limit
@@ -684,6 +686,7 @@ SelfPlayResult SelfPlayEngine::self_play(NodePool& pool, uint32_t root_idx, Infe
 
     uint32_t current = root_idx;
     game_path.push_back(current);
+    pool[current].set_on_game_path();
 
     while (current != NULL_NODE) {
         StateNode& node = pool[current];
@@ -758,6 +761,7 @@ SelfPlayResult SelfPlayEngine::self_play(NodePool& pool, uint32_t root_idx, Infe
 
         current = next;
         game_path.push_back(current);
+        pool[current].set_on_game_path();
         result.num_moves++;
 
         if (result.num_moves > 500) {

--- a/src/search/mcts.cpp
+++ b/src/search/mcts.cpp
@@ -1269,7 +1269,7 @@ SelfPlayResult SelfPlayEngine::arena_game(
         }
 
         if (policy.empty()) {
-            result.winner = 0;
+            result.error = true;;
             break;
         }
 
@@ -1293,7 +1293,7 @@ SelfPlayResult SelfPlayEngine::arena_game(
         }
 
         if (next == NULL_NODE) {
-            result.winner = 0;
+            result.error = true;
             break;
         }
 

--- a/src/tree/StateNode.cpp
+++ b/src/tree/StateNode.cpp
@@ -1,6 +1,7 @@
 #include "StateNode.h"
 #include "node_pool.h"
 #include "../util/pathfinding.h"
+#include "../inference/inference.h"
 
 #include <iostream>
 #include <sstream>
@@ -342,30 +343,36 @@ uint32_t StateNode::find_or_create_child(Move move) noexcept {
 uint32_t StateNode::test_and_add_move(Move move) noexcept {
     NodePool& p = pool();
 
-    // Check if move already exists among children
+    // Ensure valid moves mask is computed (does pathfinding once)
+    compute_valid_action_mask();
+
+    // Check mask instead of re-doing pathfinding
+    int action_idx = move_to_action_index(move);
+    if (!is_action_valid(action_idx)) {
+        return NULL_NODE;
+    }
+
+    // Acquire spinlock for thread-safe child list manipulation
+    bool expected = false;
+    while (!inserting_child.compare_exchange_weak(expected, true,
+            std::memory_order_acquire, std::memory_order_relaxed)) {
+        expected = false;
+    }
+
+    // Check if move already exists among children (must check under lock)
     uint32_t child = first_child;
     while (child != NULL_NODE) {
         if (p[child].move == move) {
+            inserting_child.store(false, std::memory_order_release);
             return NULL_NODE;  // Already exists
         }
         child = p[child].next_sibling;
     }
 
-    if (!is_move_valid(move)) {
-        return NULL_NODE;
-    }
-
-    // For fence moves, validate pathfinding
-    if (move.is_fence()) {
-        Pathfinder& pf = get_pathfinder();
-        if (!pf.check_paths_with_fence(*this, move)) {
-            return NULL_NODE;
-        }
-    }
-
-    // Allocate and initialize the child
+    // Allocate and initialize the child (no pathfinding needed - mask already validated)
     uint32_t child_idx = p.allocate();
     if (child_idx == NULL_NODE) {
+        inserting_child.store(false, std::memory_order_release);
         return NULL_NODE;
     }
 
@@ -375,6 +382,89 @@ uint32_t StateNode::test_and_add_move(Move move) noexcept {
     p[child_idx].next_sibling = first_child;
     first_child = child_idx;
 
+    inserting_child.store(false, std::memory_order_release);
+    return child_idx;
+}
+
+void StateNode::compute_valid_action_mask() noexcept {
+    // Fast path: already computed
+    if (valid_moves_computed.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    // Try to claim the right to compute
+    bool expected = false;
+    if (!computing_mask.compare_exchange_strong(expected, true,
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+        // Another thread is computing - spin until done
+        while (!valid_moves_computed.load(std::memory_order_acquire)) {
+            // Busy wait (could add pause/yield for better performance)
+        }
+        return;
+    }
+
+    // We won the CAS - compute the mask
+    for (auto& word : valid_action_mask) word = 0;
+
+    std::vector<Move> moves = generate_valid_moves();
+    Pathfinder& pf = get_pathfinder();
+
+    for (const Move& m : moves) {
+        if (m.is_fence() && !pf.check_paths_with_fence(*this, m)) {
+            continue;
+        }
+        int action_idx = move_to_action_index(m);
+        set_action_valid(action_idx);
+    }
+
+    // Mark as complete - other threads waiting on this will now see the full mask
+    valid_moves_computed.store(true, std::memory_order_release);
+}
+
+uint32_t StateNode::add_child_for_action(int action_idx) noexcept {
+    if (!is_action_valid(action_idx)) {
+        return NULL_NODE;
+    }
+
+    Move move = action_index_to_move(action_idx);
+    if (!move.is_valid()) {
+        return NULL_NODE;
+    }
+
+    NodePool& p = pool();
+
+    // Acquire spinlock for thread-safe child list manipulation
+    bool expected = false;
+    while (!inserting_child.compare_exchange_weak(expected, true,
+            std::memory_order_acquire, std::memory_order_relaxed)) {
+        expected = false;
+    }
+
+    // Check if child already exists (must check under lock)
+    uint32_t child = first_child;
+    while (child != NULL_NODE) {
+        if (p[child].move == move) {
+            inserting_child.store(false, std::memory_order_release);
+            return child;  // Already exists, return it
+        }
+        child = p[child].next_sibling;
+    }
+
+    // Allocate new child (no pathfinding needed - mask already validated)
+    uint32_t child_idx = p.allocate();
+    if (child_idx == NULL_NODE) {
+        inserting_child.store(false, std::memory_order_release);
+        return NULL_NODE;
+    }
+
+    p[child_idx].init_from_parent(*this, move, self_index);
+    p[child_idx].stats.prior = policy_priors[action_idx];
+
+    // Insert at head of children list
+    p[child_idx].next_sibling = first_child;
+    first_child = child_idx;
+
+    inserting_child.store(false, std::memory_order_release);
     return child_idx;
 }
 

--- a/src/tree/StateNode.h
+++ b/src/tree/StateNode.h
@@ -337,9 +337,10 @@ struct alignas(64) StateNode {
 
     // State flags
     uint8_t flags{0};
-    static constexpr uint8_t FLAG_EXPANDED   = 0x01;  // Children have been generated
-    static constexpr uint8_t FLAG_TERMINAL   = 0x02;  // Game over at this node
-    static constexpr uint8_t FLAG_P1_TO_MOVE = 0x04;  // Player 1's turn (else P2)
+    static constexpr uint8_t FLAG_EXPANDED     = 0x01;  // Children have been generated
+    static constexpr uint8_t FLAG_TERMINAL     = 0x02;  // Game over at this node
+    static constexpr uint8_t FLAG_P1_TO_MOVE   = 0x04;  // Player 1's turn (else P2)
+    static constexpr uint8_t FLAG_ON_GAME_PATH = 0x08;  // Node was visited in actual game
 
     // Terminal value (only valid if FLAG_TERMINAL is set)
     // +1.0 = P1 wins, -1.0 = P2 wins, 0.0 = draw (if applicable)
@@ -453,6 +454,10 @@ struct alignas(64) StateNode {
         flags |= FLAG_TERMINAL;
         terminal_value = value;
     }
+
+    [[nodiscard]] bool is_on_game_path() const noexcept { return flags & FLAG_ON_GAME_PATH; }
+    void set_on_game_path() noexcept { flags |= FLAG_ON_GAME_PATH; }
+    void clear_on_game_path() noexcept { flags &= ~FLAG_ON_GAME_PATH; }
 
     /// Get current player reference
     [[nodiscard]] const Player& current_player() const noexcept {

--- a/src/tree/node_pool.h
+++ b/src/tree/node_pool.h
@@ -310,7 +310,7 @@ private:
 
         std::cout << "[NodePool] Grew to " << chunks_.size() << " chunks ("
                   << total_capacity_.load(std::memory_order_relaxed) << " nodes) in "
-                  << duration_us << " us\n";
+                  << duration_us << " us" << std::endl;
     }
 
     /// Add a new chunk without holding the grow mutex

--- a/src/tree/node_pool.h
+++ b/src/tree/node_pool.h
@@ -310,7 +310,7 @@ private:
 
         std::cout << "[NodePool] Grew to " << chunks_.size() << " chunks ("
                   << total_capacity_.load(std::memory_order_relaxed) << " nodes) in "
-                  << duration_us << " us (no copy needed)\n";
+                  << duration_us << " us\n";
     }
 
     /// Add a new chunk without holding the grow mutex

--- a/src/tree/node_pool.h
+++ b/src/tree/node_pool.h
@@ -463,6 +463,7 @@ private:
 };
 
 /// Helper to allocate multiple children atomically
+/// Test only workflows
 class ChildBuilder {
 public:
     explicit ChildBuilder(NodePool& pool, uint32_t parent_idx)

--- a/src/util/storage.h
+++ b/src/util/storage.h
@@ -119,6 +119,16 @@ public:
         const NodePool& pool,
         uint32_t root);
 
+    /// Save only nodes marked as on_game_path (pruned tree)
+    /// @param path Output file path
+    /// @param pool Node pool containing the tree
+    /// @param root Root node index
+    /// @return Success or error, and number of nodes saved
+    [[nodiscard]] static std::expected<size_t, StorageError> save_pruned(
+        const std::filesystem::path& path,
+        const NodePool& pool,
+        uint32_t root);
+
     /// Load a tree from a file
     /// @param path Input file path
     /// @return Loaded tree or error

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -1,0 +1,137 @@
+#pragma once
+
+/// Simple profiling timers for self-play performance analysis
+/// Usage:
+///   ProfileTimers timers;
+///   { ScopedTimer t(timers.expansion); do_expansion(); }
+///   timers.print();
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <iomanip>
+
+namespace qbot {
+
+/// Accumulator for a single timed section
+struct TimerAccumulator {
+    std::atomic<uint64_t> total_ns{0};
+    std::atomic<uint64_t> count{0};
+
+    void add(uint64_t ns) noexcept {
+        total_ns.fetch_add(ns, std::memory_order_relaxed);
+        count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void reset() noexcept {
+        total_ns.store(0, std::memory_order_relaxed);
+        count.store(0, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] double total_ms() const noexcept {
+        return static_cast<double>(total_ns.load(std::memory_order_relaxed)) / 1e6;
+    }
+
+    [[nodiscard]] double avg_us() const noexcept {
+        uint64_t c = count.load(std::memory_order_relaxed);
+        if (c == 0) return 0.0;
+        return static_cast<double>(total_ns.load(std::memory_order_relaxed)) / (c * 1000.0);
+    }
+};
+
+/// RAII timer that adds elapsed time to an accumulator on destruction
+class ScopedTimer {
+public:
+    explicit ScopedTimer(TimerAccumulator& acc) noexcept
+        : acc_(acc), start_(std::chrono::high_resolution_clock::now()) {}
+
+    ~ScopedTimer() {
+        auto end = std::chrono::high_resolution_clock::now();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start_).count();
+        acc_.add(static_cast<uint64_t>(ns));
+    }
+
+    ScopedTimer(const ScopedTimer&) = delete;
+    ScopedTimer& operator=(const ScopedTimer&) = delete;
+
+private:
+    TimerAccumulator& acc_;
+    std::chrono::high_resolution_clock::time_point start_;
+};
+
+/// All timers for self-play profiling
+struct SelfPlayTimers {
+    TimerAccumulator expansion;        // expand_with_nn_priors
+    TimerAccumulator mcts_iterations;  // run_mcts_iterations (all iterations for one move)
+    TimerAccumulator single_mcts;      // single mcts_iteration
+    TimerAccumulator policy_compute;   // compute_policy_from_q
+    TimerAccumulator move_selection;   // select_move_from_policy
+    TimerAccumulator child_lookup;     // finding child for selected move
+    TimerAccumulator backprop;         // backpropagation
+    TimerAccumulator nn_batch_eval;    // NN batch evaluation specifically
+    TimerAccumulator nn_single_eval;   // NN single node evaluation
+    TimerAccumulator generate_children;// generate_valid_children
+
+    // Detailed inference breakdown
+    TimerAccumulator tensor_alloc;     // torch::zeros calls
+    TimerAccumulator tensor_fill;      // filling tensor data
+    TimerAccumulator tensor_to_gpu;    // .to(device_) transfer
+    TimerAccumulator model_forward;    // model_.forward()
+    TimerAccumulator tensor_to_cpu;    // output.to(kCPU)
+
+    void reset() noexcept {
+        expansion.reset();
+        mcts_iterations.reset();
+        single_mcts.reset();
+        policy_compute.reset();
+        move_selection.reset();
+        child_lookup.reset();
+        backprop.reset();
+        nn_batch_eval.reset();
+        nn_single_eval.reset();
+        generate_children.reset();
+        tensor_alloc.reset();
+        tensor_fill.reset();
+        tensor_to_gpu.reset();
+        model_forward.reset();
+        tensor_to_cpu.reset();
+    }
+
+    void print() const {
+        auto print_line = [](const char* name, const TimerAccumulator& t) {
+            std::cout << "  " << std::left << std::setw(20) << name
+                      << std::right << std::setw(10) << std::fixed << std::setprecision(1)
+                      << t.total_ms() << " ms"
+                      << std::setw(12) << t.count.load(std::memory_order_relaxed) << " calls"
+                      << std::setw(10) << std::setprecision(2) << t.avg_us() << " us/call\n";
+        };
+
+        std::cout << "\n=== Self-Play Timing Breakdown ===\n";
+        print_line("mcts_iterations", mcts_iterations);
+        print_line("  single_mcts", single_mcts);
+        print_line("expansion", expansion);
+        print_line("  generate_children", generate_children);
+        print_line("  nn_batch_eval", nn_batch_eval);
+        print_line("nn_single_eval", nn_single_eval);
+        print_line("policy_compute", policy_compute);
+        print_line("move_selection", move_selection);
+        print_line("child_lookup", child_lookup);
+        print_line("backprop", backprop);
+        std::cout << "--- Inference Detail ---\n";
+        print_line("  tensor_alloc", tensor_alloc);
+        print_line("  tensor_fill", tensor_fill);
+        print_line("  tensor_to_gpu", tensor_to_gpu);
+        print_line("  model_forward", model_forward);
+        print_line("  tensor_to_cpu", tensor_to_cpu);
+        std::cout << "==================================\n\n";
+    }
+};
+
+/// Global timers instance (thread-safe due to atomics)
+inline SelfPlayTimers& get_timers() {
+    static SelfPlayTimers timers;
+    return timers;
+}
+
+} // namespace qbot

--- a/src/util/training_samples.cpp
+++ b/src/util/training_samples.cpp
@@ -1,0 +1,196 @@
+#include "training_samples.h"
+
+#include <chrono>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+namespace qbot {
+
+std::array<float, NUM_ACTIONS> extract_visit_distribution(
+    const NodePool& pool, uint32_t node_idx) noexcept
+{
+    std::array<float, NUM_ACTIONS> policy{};  // Zero-initialized
+
+    const StateNode& parent = pool[node_idx];
+    if (!parent.has_children()) {
+        // No children - return uniform over all actions as fallback
+        float uniform = 1.0f / NUM_ACTIONS;
+        for (auto& p : policy) p = uniform;
+        return policy;
+    }
+
+    // First pass: sum total visits across all children
+    uint32_t total_visits = 0;
+    uint32_t child = parent.first_child;
+    while (child != NULL_NODE) {
+        total_visits += pool[child].stats.visits.load(std::memory_order_relaxed);
+        child = pool[child].next_sibling;
+    }
+
+    if (total_visits == 0) {
+        // No visits recorded - use priors as fallback
+        child = parent.first_child;
+        while (child != NULL_NODE) {
+            int action_idx = move_to_action_index(pool[child].move);
+            if (action_idx >= 0 && action_idx < NUM_ACTIONS) {
+                policy[action_idx] = pool[child].stats.prior;
+            }
+            child = pool[child].next_sibling;
+        }
+        return policy;
+    }
+
+    // Second pass: convert visit counts to probabilities
+    child = parent.first_child;
+    while (child != NULL_NODE) {
+        int action_idx = move_to_action_index(pool[child].move);
+        if (action_idx >= 0 && action_idx < NUM_ACTIONS) {
+            uint32_t visits = pool[child].stats.visits.load(std::memory_order_relaxed);
+            policy[action_idx] = static_cast<float>(visits) / static_cast<float>(total_visits);
+        }
+        child = pool[child].next_sibling;
+    }
+
+    return policy;
+}
+
+// ============================================================================
+// TrainingSampleStorage Implementation
+// ============================================================================
+
+std::expected<void, TrainingSampleError> TrainingSampleStorage::save(
+    const std::filesystem::path& path,
+    const std::vector<TrainingSample>& samples)
+{
+    if (samples.empty()) {
+        return std::unexpected(TrainingSampleError::NoSamples);
+    }
+
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    // Write header
+    TrainingSampleHeader header;
+    header.sample_count = static_cast<uint32_t>(samples.size());
+    header.timestamp = static_cast<uint64_t>(
+        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
+
+    file.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    // Write samples
+    file.write(reinterpret_cast<const char*>(samples.data()),
+               static_cast<std::streamsize>(samples.size() * sizeof(TrainingSample)));
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    std::cout << "[TrainingSampleStorage] Saved " << samples.size() << " samples to " << path << "\n";
+    return {};
+}
+
+std::expected<std::vector<TrainingSample>, TrainingSampleError> TrainingSampleStorage::load(
+    const std::filesystem::path& path)
+{
+    if (!std::filesystem::exists(path)) {
+        return std::unexpected(TrainingSampleError::FileNotFound);
+    }
+
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    // Read header
+    TrainingSampleHeader header;
+    file.read(reinterpret_cast<char*>(&header), sizeof(header));
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    if (!header.is_valid()) {
+        return std::unexpected(TrainingSampleError::InvalidFormat);
+    }
+
+    if (header.version > TrainingSampleHeader::CURRENT_VERSION) {
+        return std::unexpected(TrainingSampleError::VersionMismatch);
+    }
+
+    // Read samples
+    std::vector<TrainingSample> samples(header.sample_count);
+    file.read(reinterpret_cast<char*>(samples.data()),
+              static_cast<std::streamsize>(header.sample_count * sizeof(TrainingSample)));
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    std::cout << "[TrainingSampleStorage] Loaded " << samples.size() << " samples from " << path << "\n";
+    return samples;
+}
+
+std::expected<TrainingSampleHeader, TrainingSampleError> TrainingSampleStorage::read_header(
+    const std::filesystem::path& path)
+{
+    if (!std::filesystem::exists(path)) {
+        return std::unexpected(TrainingSampleError::FileNotFound);
+    }
+
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    TrainingSampleHeader header;
+    file.read(reinterpret_cast<char*>(&header), sizeof(header));
+    if (!file) {
+        return std::unexpected(TrainingSampleError::IoError);
+    }
+
+    if (!header.is_valid()) {
+        return std::unexpected(TrainingSampleError::InvalidFormat);
+    }
+
+    return header;
+}
+
+// ============================================================================
+// TrainingSampleCollector Implementation
+// ============================================================================
+
+void TrainingSampleCollector::reserve(size_t count) {
+    std::lock_guard lock(mutex_);
+    samples_.reserve(count);
+}
+
+void TrainingSampleCollector::add_sample(const NodePool& pool, uint32_t node_idx, float game_outcome) {
+    const StateNode& node = pool[node_idx];
+
+    TrainingSample sample;
+
+    // Extract compact state
+    sample.state = extract_compact_state(node);
+
+    // Extract MCTS visit distribution as policy target
+    sample.policy = extract_visit_distribution(pool, node_idx);
+
+    // Value target: game outcome from current player's perspective
+    // game_outcome is from P1's perspective (+1 = P1 wins)
+    // We need it from current player's perspective
+    bool is_p1_turn = node.is_p1_to_move();
+    sample.value = is_p1_turn ? game_outcome : -game_outcome;
+
+    std::lock_guard lock(mutex_);
+    samples_.push_back(sample);
+}
+
+std::vector<TrainingSample> TrainingSampleCollector::take_samples() noexcept {
+    std::lock_guard lock(mutex_);
+    return std::move(samples_);
+}
+
+} // namespace qbot

--- a/src/util/training_samples.h
+++ b/src/util/training_samples.h
@@ -164,6 +164,14 @@ public:
     }
 };
 
+/// Extract training samples from a pruned game tree
+/// Traverses the tree and extracts samples from all non-terminal nodes with children
+/// @param pool Node pool containing the tree
+/// @param root_idx Root node index
+/// @return Vector of extracted training samples
+[[nodiscard]] std::vector<TrainingSample> extract_samples_from_tree(
+    const NodePool& pool, uint32_t root_idx);
+
 /// Collector for gathering training samples during self-play
 /// Thread-safe for use with multi-threaded self-play
 class TrainingSampleCollector {
@@ -176,6 +184,9 @@ public:
     /// @param node_idx Index of the position node
     /// @param game_outcome Final game outcome (+1 P1 win, -1 P2 win, 0 draw)
     void add_sample(const NodePool& pool, uint32_t node_idx, float game_outcome);
+
+    /// Add a pre-constructed sample directly
+    void add_sample_direct(TrainingSample sample);
 
     /// Get collected samples
     [[nodiscard]] const std::vector<TrainingSample>& samples() const noexcept { return samples_; }

--- a/src/util/training_samples.h
+++ b/src/util/training_samples.h
@@ -1,0 +1,197 @@
+#pragma once
+
+/// Training Sample Storage for AlphaZero-style training
+///
+/// Stores training samples with:
+/// - Board state (compact representation)
+/// - MCTS visit distribution (policy target)
+/// - Game outcome (value target)
+///
+/// File format (.qsamples):
+///   Header (64 bytes)
+///   TrainingSample[] (variable size based on sample_count)
+
+#include "../tree/StateNode.h"
+#include "../tree/node_pool.h"
+#include "../inference/inference.h"
+
+#include <array>
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <string_view>
+#include <vector>
+
+namespace qbot {
+
+/// Error codes for training sample operations
+enum class TrainingSampleError {
+    FileNotFound,
+    PermissionDenied,
+    InvalidFormat,
+    VersionMismatch,
+    CorruptedData,
+    IoError,
+    NoSamples,
+};
+
+[[nodiscard]] constexpr std::string_view to_string(TrainingSampleError err) noexcept {
+    switch (err) {
+        case TrainingSampleError::FileNotFound:     return "File not found";
+        case TrainingSampleError::PermissionDenied: return "Permission denied";
+        case TrainingSampleError::InvalidFormat:    return "Invalid file format";
+        case TrainingSampleError::VersionMismatch:  return "Version mismatch";
+        case TrainingSampleError::CorruptedData:    return "Corrupted data";
+        case TrainingSampleError::IoError:          return "I/O error";
+        case TrainingSampleError::NoSamples:        return "No samples";
+    }
+    return "Unknown error";
+}
+
+/// File header for training samples format
+struct TrainingSampleHeader {
+    static constexpr uint32_t MAGIC = 0x51534D50;  // "QSMP" in little-endian
+    static constexpr uint16_t CURRENT_VERSION = 1;
+
+    uint32_t magic = MAGIC;
+    uint16_t version = CURRENT_VERSION;
+    uint16_t flags = 0;
+    uint32_t sample_count = 0;
+    uint32_t reserved1 = 0;
+    uint64_t timestamp = 0;
+
+    // Reserved for future use
+    uint8_t reserved[40] = {};
+
+    [[nodiscard]] bool is_valid() const noexcept {
+        return magic == MAGIC && version <= CURRENT_VERSION;
+    }
+};
+
+static_assert(sizeof(TrainingSampleHeader) == 64, "Header should be 64 bytes");
+
+/// Compact state representation for training samples
+/// Contains just enough info to reconstruct input tensor
+struct CompactState {
+    // Player positions (4 bytes)
+    uint8_t p1_row;
+    uint8_t p1_col;
+    uint8_t p2_row;
+    uint8_t p2_col;
+
+    // Fence counts (2 bytes)
+    uint8_t p1_fences;
+    uint8_t p2_fences;
+
+    // Flags (1 byte) - includes whose turn it is
+    uint8_t flags;
+
+    // Reserved for alignment (1 byte)
+    uint8_t reserved;
+
+    // Fence grids (16 bytes)
+    uint64_t fences_horizontal;
+    uint64_t fences_vertical;
+};
+
+static_assert(sizeof(CompactState) == 24, "CompactState should be 24 bytes");
+
+/// Single training sample with state, policy target, and value target
+/// Policy is stored as visit counts (will be normalized during training)
+struct TrainingSample {
+    // Board state (24 bytes)
+    CompactState state;
+
+    // MCTS visit distribution - 209 actions (836 bytes as floats)
+    // Stored as proportions (0.0-1.0), already normalized
+    std::array<float, NUM_ACTIONS> policy;
+
+    // Game outcome from current player's perspective (4 bytes)
+    // +1.0 = current player won, -1.0 = current player lost, 0.0 = draw
+    float value;
+};
+
+static_assert(sizeof(TrainingSample) == 864, "TrainingSample should be 864 bytes");
+
+/// Extract compact state from a StateNode
+[[nodiscard]] inline CompactState extract_compact_state(const StateNode& node) noexcept {
+    CompactState state;
+    state.p1_row = node.p1.row;
+    state.p1_col = node.p1.col;
+    state.p2_row = node.p2.row;
+    state.p2_col = node.p2.col;
+    state.p1_fences = node.p1.fences;
+    state.p2_fences = node.p2.fences;
+    state.flags = static_cast<uint8_t>(node.flags);
+    state.reserved = 0;
+    state.fences_horizontal = node.fences.horizontal;
+    state.fences_vertical = node.fences.vertical;
+    return state;
+}
+
+/// Extract visit distribution from a node's children
+/// Returns normalized probabilities (sum to 1.0)
+/// @param pool Node pool
+/// @param node_idx Index of parent node
+/// @return Policy distribution over 209 actions
+[[nodiscard]] std::array<float, NUM_ACTIONS> extract_visit_distribution(
+    const NodePool& pool, uint32_t node_idx) noexcept;
+
+/// Training sample storage operations
+class TrainingSampleStorage {
+public:
+    /// Save training samples to a file
+    /// @param path Output file path
+    /// @param samples Vector of training samples
+    /// @return Success or error
+    [[nodiscard]] static std::expected<void, TrainingSampleError> save(
+        const std::filesystem::path& path,
+        const std::vector<TrainingSample>& samples);
+
+    /// Load training samples from a file
+    /// @param path Input file path
+    /// @return Vector of samples or error
+    [[nodiscard]] static std::expected<std::vector<TrainingSample>, TrainingSampleError> load(
+        const std::filesystem::path& path);
+
+    /// Read just the header from a file (for inspection)
+    [[nodiscard]] static std::expected<TrainingSampleHeader, TrainingSampleError> read_header(
+        const std::filesystem::path& path);
+
+    /// Estimate file size for given sample count
+    [[nodiscard]] static constexpr size_t estimate_file_size(size_t sample_count) noexcept {
+        return sizeof(TrainingSampleHeader) + sample_count * sizeof(TrainingSample);
+    }
+};
+
+/// Collector for gathering training samples during self-play
+/// Thread-safe for use with multi-threaded self-play
+class TrainingSampleCollector {
+public:
+    /// Reserve space for expected number of samples
+    void reserve(size_t count);
+
+    /// Add a sample from a position after MCTS search
+    /// @param pool Node pool
+    /// @param node_idx Index of the position node
+    /// @param game_outcome Final game outcome (+1 P1 win, -1 P2 win, 0 draw)
+    void add_sample(const NodePool& pool, uint32_t node_idx, float game_outcome);
+
+    /// Get collected samples
+    [[nodiscard]] const std::vector<TrainingSample>& samples() const noexcept { return samples_; }
+
+    /// Move out samples (clears collector)
+    [[nodiscard]] std::vector<TrainingSample> take_samples() noexcept;
+
+    /// Get current sample count
+    [[nodiscard]] size_t size() const noexcept { return samples_.size(); }
+
+    /// Clear all samples
+    void clear() noexcept { samples_.clear(); }
+
+private:
+    std::vector<TrainingSample> samples_;
+    mutable std::mutex mutex_;
+};
+
+} // namespace qbot

--- a/src/util/training_samples.h
+++ b/src/util/training_samples.h
@@ -165,7 +165,9 @@ public:
 };
 
 /// Extract training samples from a pruned game tree
-/// Traverses the tree and extracts samples from all non-terminal nodes with children
+/// Only extracts from nodes marked as on_game_path (part of a completed game with
+/// win/loss backpropagated). This ensures training data only includes positions
+/// with known outcomes, not speculative tree exploration.
 /// @param pool Node pool containing the tree
 /// @param root_idx Root node index
 /// @return Vector of extracted training samples

--- a/tests/bench_inference.cpp
+++ b/tests/bench_inference.cpp
@@ -1,0 +1,245 @@
+#include "inference/inference.h"
+#include "core/Game.h"
+#include "tree/StateNode.h"
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+
+using namespace qbot;
+
+namespace {
+
+const char* DEFAULT_MODEL_PATH = "/home/eamon/repos/qbot/model/tree.pt";
+const char* TEST_MODEL_PATH = "/tmp/test_model.pt";
+
+bool create_test_model() {
+    const char* script = R"(
+import sys
+sys.path.insert(0, '/home/eamon/repos/qbot/train')
+import torch
+from resnet import QuoridorValueNet
+
+model = QuoridorValueNet()
+model.eval()
+
+example_pawn = torch.zeros(1, 2, 9, 9)
+example_wall = torch.zeros(1, 2, 8, 8)
+example_meta = torch.zeros(1, 3)
+
+traced = torch.jit.trace(model, (example_pawn, example_wall, example_meta))
+traced.save('/tmp/test_model.pt')
+print('Model saved successfully')
+)";
+
+    std::string cmd = "python3 -c \"" + std::string(script) + "\" 2>&1";
+    int result = std::system(cmd.c_str());
+    return result == 0;
+}
+
+bool is_model_compatible(const std::string& path) {
+    try {
+        ModelInference inference(path, 1, false);
+        if (!inference.is_ready()) return false;
+
+        StateNode dummy;
+        dummy.init_root(true);
+        inference.evaluate_node(&dummy);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+std::string get_model_path() {
+    std::ifstream default_model(DEFAULT_MODEL_PATH);
+    if (default_model.good() && is_model_compatible(DEFAULT_MODEL_PATH)) {
+        return DEFAULT_MODEL_PATH;
+    }
+    if (create_test_model()) {
+        return TEST_MODEL_PATH;
+    }
+    return "";
+}
+
+}  // namespace
+
+class InferenceBenchmark : public ::testing::Test {
+protected:
+    void SetUp() override {
+        GameConfig config;
+        config.pool_capacity = 10'000;
+        game_ = std::make_unique<Game>(config);
+    }
+
+    std::unique_ptr<Game> game_;
+};
+
+// Benchmark test for measuring inference latency at various batch sizes
+TEST_F(InferenceBenchmark, BatchSizes) {
+    std::string model_path = get_model_path();
+    if (model_path.empty()) {
+        GTEST_SKIP() << "No model available (requires Python with PyTorch)";
+        return;
+    }
+
+    try {
+        ModelInference inference(model_path, 512, true);  // Max batch size
+        ASSERT_TRUE(inference.is_ready());
+
+        std::cout << "\n";
+        std::cout << "╔═══════════════════════════════════════════════════════════════════════╗\n";
+        std::cout << "║                    Inference Batch Size Benchmark                     ║\n";
+        std::cout << "╠═══════════════════════════════════════════════════════════════════════╣\n";
+        std::cout << "║  Model: " << std::left << std::setw(62) << model_path.substr(model_path.find_last_of('/') + 1) << "║\n";
+        std::cout << "║  Device: " << std::left << std::setw(61) << (torch::cuda::is_available() ? "CUDA" : "CPU") << "║\n";
+        std::cout << "╠═════════════╦═══════════════╦═══════════════╦═════════════════════════╣\n";
+        std::cout << "║ Batch Size  ║   Total (ms)  ║  Per Node(µs) ║     Throughput (n/s)    ║\n";
+        std::cout << "╠═════════════╬═══════════════╬═══════════════╬═════════════════════════╣\n";
+
+        std::vector<int> batch_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512};
+
+        constexpr int WARMUP_RUNS = 3;
+        constexpr int MEASURE_RUNS = 10;
+
+        for (int batch_size : batch_sizes) {
+            std::vector<StateNode> nodes(batch_size);
+            std::vector<const StateNode*> node_ptrs;
+            node_ptrs.reserve(batch_size);
+
+            std::mt19937 rng(42);
+            for (int i = 0; i < batch_size; ++i) {
+                nodes[i].init_root(true);
+                nodes[i].p1.row = rng() % 9;
+                nodes[i].p1.col = rng() % 9;
+                nodes[i].p2.row = rng() % 9;
+                nodes[i].p2.col = rng() % 9;
+                nodes[i].p1.fences = rng() % 11;
+                nodes[i].p2.fences = rng() % 11;
+                node_ptrs.push_back(&nodes[i]);
+            }
+
+            for (int w = 0; w < WARMUP_RUNS; ++w) {
+                inference.evaluate_batch(node_ptrs);
+            }
+
+            double total_time_us = 0.0;
+            for (int r = 0; r < MEASURE_RUNS; ++r) {
+                auto start = std::chrono::high_resolution_clock::now();
+                auto results = inference.evaluate_batch(node_ptrs);
+                auto end = std::chrono::high_resolution_clock::now();
+
+                auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+                total_time_us += static_cast<double>(duration_us);
+
+                ASSERT_EQ(results.size(), static_cast<size_t>(batch_size));
+            }
+
+            double avg_time_us = total_time_us / MEASURE_RUNS;
+            double avg_time_ms = avg_time_us / 1000.0;
+            double per_node_us = avg_time_us / batch_size;
+            double throughput = 1'000'000.0 / per_node_us;
+
+            std::cout << "║ " << std::right << std::setw(10) << batch_size << "  ║ "
+                      << std::right << std::setw(12) << std::fixed << std::setprecision(3) << avg_time_ms << "  ║ "
+                      << std::right << std::setw(12) << std::fixed << std::setprecision(2) << per_node_us << "  ║ "
+                      << std::right << std::setw(22) << std::fixed << std::setprecision(0) << throughput << "   ║\n";
+        }
+
+        std::cout << "╚═════════════╩═══════════════╩═══════════════╩═════════════════════════╝\n";
+        std::cout << "\n";
+
+    } catch (const c10::Error& e) {
+        GTEST_SKIP() << "Failed to load model: " << e.what();
+    }
+}
+
+// Extended benchmark with submission latency measurement (queue -> result)
+TEST_F(InferenceBenchmark, QueueLatency) {
+    std::string model_path = get_model_path();
+    if (model_path.empty()) {
+        GTEST_SKIP() << "No model available (requires Python with PyTorch)";
+        return;
+    }
+
+    try {
+        std::vector<int> internal_batch_sizes = {8, 16, 32, 64, 128};
+        std::vector<int> submission_counts = {1, 10, 50, 100, 200};
+
+        std::cout << "\n";
+        std::cout << "╔══════════════════════════════════════════════════════════════════════════════╗\n";
+        std::cout << "║                      Queue Submission Latency Benchmark                      ║\n";
+        std::cout << "║   Measures time from queue_for_evaluation() to receiving callback result     ║\n";
+        std::cout << "╠══════════════════════════════════════════════════════════════════════════════╣\n";
+
+        for (int internal_batch : internal_batch_sizes) {
+            ModelInference inference(model_path, internal_batch, true);
+            ASSERT_TRUE(inference.is_ready());
+
+            std::cout << "║  Internal batch size: " << std::left << std::setw(55) << internal_batch << "║\n";
+            std::cout << "╠════════════════╦════════════════╦════════════════╦════════════════════════╣\n";
+            std::cout << "║  Nodes Queued  ║  Total (ms)    ║  Per Node (µs) ║  Throughput (n/s)      ║\n";
+            std::cout << "╠════════════════╬════════════════╬════════════════╬════════════════════════╣\n";
+
+            for (int num_nodes : submission_counts) {
+                std::vector<StateNode> nodes(num_nodes);
+                std::mt19937 rng(123);
+                for (int i = 0; i < num_nodes; ++i) {
+                    nodes[i].init_root(true);
+                    nodes[i].p1.row = rng() % 9;
+                    nodes[i].p1.col = rng() % 9;
+                    nodes[i].p2.row = rng() % 9;
+                    nodes[i].p2.col = rng() % 9;
+                }
+
+                constexpr int RUNS = 5;
+                double total_time_us = 0.0;
+                int total_results = 0;
+
+                for (int r = 0; r < RUNS; ++r) {
+                    auto start = std::chrono::high_resolution_clock::now();
+
+                    for (int i = 0; i < num_nodes; ++i) {
+                        inference.queue_for_evaluation(&nodes[i], static_cast<uint32_t>(i));
+                    }
+
+                    std::vector<float> results;
+                    results.reserve(num_nodes);
+                    inference.flush_queue([&results](uint32_t /*idx*/, float value) {
+                        results.push_back(value);
+                    });
+
+                    auto end = std::chrono::high_resolution_clock::now();
+                    auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+                    total_time_us += static_cast<double>(duration_us);
+                    total_results += static_cast<int>(results.size());
+                }
+
+                ASSERT_EQ(total_results, num_nodes * RUNS);
+
+                double avg_time_us = total_time_us / RUNS;
+                double avg_time_ms = avg_time_us / 1000.0;
+                double per_node_us = avg_time_us / num_nodes;
+                double throughput = 1'000'000.0 / per_node_us;
+
+                std::cout << "║ " << std::right << std::setw(13) << num_nodes << "  ║ "
+                          << std::right << std::setw(13) << std::fixed << std::setprecision(3) << avg_time_ms << "  ║ "
+                          << std::right << std::setw(13) << std::fixed << std::setprecision(2) << per_node_us << "  ║ "
+                          << std::right << std::setw(21) << std::fixed << std::setprecision(0) << throughput << "   ║\n";
+            }
+
+            std::cout << "╠════════════════╩════════════════╩════════════════╩════════════════════════╣\n";
+        }
+
+        std::cout << "╚══════════════════════════════════════════════════════════════════════════════╝\n";
+        std::cout << "\n";
+
+    } catch (const c10::Error& e) {
+        GTEST_SKIP() << "Failed to load model: " << e.what();
+    }
+}

--- a/tests/benchmarks.cpp
+++ b/tests/benchmarks.cpp
@@ -116,20 +116,20 @@ const char* DEFAULT_MODEL_PATH = "/home/eamon/repos/qbot/model/tree.pt";
 const char* TEST_MODEL_PATH = "/tmp/test_model.pt";
 
 bool create_test_model() {
+    // Create model with new unified input format (6 channels, current-player-perspective)
     const char* script = R"(
 import sys
 sys.path.insert(0, '/home/eamon/repos/qbot/train')
 import torch
-from resnet import QuoridorValueNet
+from resnet import QuoridorNet
 
-model = QuoridorValueNet()
+model = QuoridorNet()
 model.eval()
 
-example_pawn = torch.zeros(1, 2, 9, 9)
-example_wall = torch.zeros(1, 2, 8, 8)
-example_meta = torch.zeros(1, 3)
+# Create example input with unified 6-channel format (current-player-perspective)
+example_input = torch.zeros(1, 6, 9, 9)
 
-traced = torch.jit.trace(model, (example_pawn, example_wall, example_meta))
+traced = torch.jit.trace(model, example_input)
 traced.save('/tmp/test_model.pt')
 print('Model saved successfully')
 )";
@@ -195,7 +195,7 @@ TEST_F(InferenceBenchmark, BatchSizes) {
         std::cout << "║  Model: " << std::left << std::setw(62) << model_path.substr(model_path.find_last_of('/') + 1) << "║\n";
         std::cout << "║  Device: " << std::left << std::setw(61) << (torch::cuda::is_available() ? "CUDA" : "CPU") << "║\n";
         std::cout << "╠═════════════╦═══════════════╦═══════════════╦═════════════════════════╣\n";
-        std::cout << "║ Batch Size  ║   Total (ms)  ║  Per Node(µs) ║     Throughput (n/s)    ║\n";
+        std::cout << "║ Batch Size  ║   Total (ms)  ║  Per Node(us) ║     Throughput (n/s)    ║\n";
         std::cout << "╠═════════════╬═══════════════╬═══════════════╬═════════════════════════╣\n";
 
         std::vector<int> batch_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512};

--- a/tests/test_game.cpp
+++ b/tests/test_game.cpp
@@ -224,49 +224,6 @@ TEST_F(GameTest, BuildTreeTerminalNodesNotExpanded) {
     }
 }
 
-TEST_F(GameTest, BenchmarkBuildTree) {
-    // Use larger pool for benchmark
-    GameConfig config;
-    config.pool_capacity = 5'000'000;
-    game_ = std::make_unique<Game>(config);
-
-    uint32_t root = create_root();
-
-    constexpr float branching_factor = 0.5f;
-    constexpr std::time_t time_limit_sec = 3;
-    constexpr size_t node_limit = 5'000'000;
-
-    auto start = std::chrono::high_resolution_clock::now();
-    size_t created = game_->build_tree(root, branching_factor, time_limit_sec, node_limit);
-    auto end = std::chrono::high_resolution_clock::now();
-
-    auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-    auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-
-    double nodes_per_sec = (created * 1'000'000.0) / duration_us;
-    double us_per_node = static_cast<double>(duration_us) / created;
-
-    if (is_single_test_run()) {
-        std::cout << "\n========== BENCHMARK: build_tree ==========" << std::endl;
-        std::cout << "Parameters:" << std::endl;
-        std::cout << "  branching_factor: " << branching_factor << std::endl;
-        std::cout << "  time_limit:       " << time_limit_sec << " sec" << std::endl;
-        std::cout << "  node_limit:       " << node_limit << std::endl;
-        std::cout << "Results:" << std::endl;
-        std::cout << "  Nodes created:    " << created << std::endl;
-        std::cout << "  Time elapsed:     " << duration_ms << " ms" << std::endl;
-        std::cout << "  Throughput:       " << static_cast<int>(nodes_per_sec) << " nodes/sec" << std::endl;
-        std::cout << "  Per-node time:    " << us_per_node << " µs/node" << std::endl;
-        std::cout << "============================================\n" << std::endl;
-    }
-
-    EXPECT_GT(created, 0) << "Should create nodes";
-
-    // Verify tree integrity
-    size_t counted = count_tree_nodes(root);
-    EXPECT_EQ(counted, created + 1) << "Tree count should match";
-}
-
 TEST_F(GameTest, BuildTreeUntilWinAndPrintPath) {
     // Use larger pool for this test
     GameConfig config;

--- a/train/StateNode.py
+++ b/train/StateNode.py
@@ -58,16 +58,21 @@ class TrainingSampleDataset:
     them ideal for AlphaZero-style training where policy targets come from
     MCTS search rather than move labels.
 
+    By default, loads all samples into memory and shuffles them for better training.
+    Use stream=True for memory-efficient streaming from disk (no shuffling).
+
     Output format per sample:
         state: (6, 9, 9) tensor - current-player-perspective board representation
         policy_target: (209,) tensor - MCTS visit distribution
         value_target: (1,) tensor - game outcome from current player's view
     """
 
-    def __init__(self, samples_path: str, batch_size: int):
+    def __init__(self, samples_path: str, batch_size: int, stream: bool = False):
         self.samples_path = samples_path
         self.batch_size = batch_size
+        self.stream = stream
         self.file = None
+        self.samples = None  # In-memory storage when not streaming
 
     def __enter__(self):
         self.file = open(self.samples_path, 'rb')
@@ -83,7 +88,22 @@ class TrainingSampleDataset:
             raise ValueError(f"Unsupported .qsamples version: {version}")
 
         self.sample_count = sample_count
-        logging.info(f"Opened {self.samples_path}: {sample_count} samples")
+
+        if not self.stream:
+            # Load all samples into memory
+            logging.info(f"Loading {sample_count} samples from {self.samples_path} into memory...")
+            self.samples = []
+            for _ in range(sample_count):
+                sample_data = self.file.read(TRAINING_SAMPLE_SIZE)
+                if len(sample_data) < TRAINING_SAMPLE_SIZE:
+                    break
+                self.samples.append(self._parse_sample(sample_data))
+            self.file.close()
+            self.file = None
+            logging.info(f"Loaded {len(self.samples)} samples into memory")
+        else:
+            logging.info(f"Opened {self.samples_path}: {sample_count} samples (streaming mode)")
+
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -162,37 +182,287 @@ class TrainingSampleDataset:
         return tensor
 
     def generate_batches(self):
-        """Generate batches of training data."""
-        if not self.file:
-            raise RuntimeError("Dataset not initialized with context manager")
+        """
+        Generate batches of training data.
 
-        states, policies, values = [], [], []
+        In-memory mode (default): Shuffles samples before generating batches.
+        Streaming mode: Reads samples sequentially from disk.
+        """
+        if self.stream:
+            # Streaming mode: read from file
+            if not self.file:
+                raise RuntimeError("Dataset not initialized with context manager")
 
-        for _ in range(self.sample_count):
-            sample_data = self.file.read(TRAINING_SAMPLE_SIZE)
-            if len(sample_data) < TRAINING_SAMPLE_SIZE:
-                break
+            states, policies, values = [], [], []
 
-            state_t, policy_t, value_t = self._parse_sample(sample_data)
-            states.append(state_t)
-            policies.append(policy_t)
-            values.append(value_t)
+            for _ in range(self.sample_count):
+                sample_data = self.file.read(TRAINING_SAMPLE_SIZE)
+                if len(sample_data) < TRAINING_SAMPLE_SIZE:
+                    break
 
-            if len(states) == self.batch_size:
+                state_t, policy_t, value_t = self._parse_sample(sample_data)
+                states.append(state_t)
+                policies.append(policy_t)
+                values.append(value_t)
+
+                if len(states) == self.batch_size:
+                    yield (
+                        torch.stack(states),
+                        torch.stack(policies),
+                        torch.stack(values)
+                    )
+                    states, policies, values = [], [], []
+
+            # Yield remaining samples
+            if states:
                 yield (
                     torch.stack(states),
                     torch.stack(policies),
                     torch.stack(values)
                 )
-                states, policies, values = [], [], []
+        else:
+            # In-memory mode: shuffle and generate batches
+            if self.samples is None:
+                raise RuntimeError("Dataset not initialized with context manager")
 
-        # Yield remaining samples
-        if states:
-            yield (
-                torch.stack(states),
-                torch.stack(policies),
-                torch.stack(values)
-            )
+            # Shuffle samples for better training
+            import random
+            indices = list(range(len(self.samples)))
+            random.shuffle(indices)
+
+            # Generate batches from shuffled indices
+            for i in range(0, len(indices), self.batch_size):
+                batch_indices = indices[i:i + self.batch_size]
+                states = [self.samples[idx][0] for idx in batch_indices]
+                policies = [self.samples[idx][1] for idx in batch_indices]
+                values = [self.samples[idx][2] for idx in batch_indices]
+
+                yield (
+                    torch.stack(states),
+                    torch.stack(policies),
+                    torch.stack(values)
+                )
+
+
+class MultiFileTrainingSampleDataset:
+    """
+    Dataset loader that concatenates multiple .qsamples files into a single dataset.
+
+    This is useful for training on accumulated samples from the same model version,
+    where multiple self-play runs generated separate sample files.
+
+    By default, loads all samples from all files into memory and shuffles them.
+    Use stream=True for memory-efficient streaming (no shuffling, files read sequentially).
+
+    Usage:
+        with MultiFileTrainingSampleDataset(['tree_0.qsamples', 'tree_1.qsamples'], 64) as dataset:
+            for batch in dataset.generate_batches():
+                train_step(model, batch)
+    """
+
+    def __init__(self, samples_paths: list[str], batch_size: int, stream: bool = False):
+        """
+        Args:
+            samples_paths: List of .qsamples file paths to load
+            batch_size: Batch size for training
+            stream: If False (default), load all into memory and shuffle. If True, stream from disk.
+        """
+        self.samples_paths = samples_paths
+        self.batch_size = batch_size
+        self.stream = stream
+        self.total_samples = 0
+        self.samples = None  # In-memory storage when not streaming
+
+    def __enter__(self):
+        if not self.stream:
+            # Load all samples into memory from all files
+            logging.info(f"Loading samples from {len(self.samples_paths)} files into memory...")
+            self.samples = []
+
+            for path in self.samples_paths:
+                with open(path, 'rb') as f:
+                    header_data = f.read(QSMP_HEADER_SIZE)
+                    if len(header_data) < QSMP_HEADER_SIZE:
+                        raise ValueError(f"Invalid .qsamples file: {path}")
+
+                    magic, version, flags, sample_count = struct.unpack('<IHHI', header_data[:12])
+                    if magic != QSMP_MAGIC:
+                        raise ValueError(f"Invalid .qsamples file: bad magic in {path}")
+                    if version > 1:
+                        raise ValueError(f"Unsupported .qsamples version in {path}: {version}")
+
+                    logging.info(f"  {path}: {sample_count} samples")
+
+                    # Load all samples from this file
+                    for _ in range(sample_count):
+                        sample_data = f.read(TRAINING_SAMPLE_SIZE)
+                        if len(sample_data) < TRAINING_SAMPLE_SIZE:
+                            break
+                        self.samples.append(self._parse_sample(sample_data))
+
+            self.total_samples = len(self.samples)
+            logging.info(f"Loaded {self.total_samples} total samples into memory")
+        else:
+            # Streaming mode: just count samples
+            logging.info(f"Opening {len(self.samples_paths)} files for streaming...")
+            for path in self.samples_paths:
+                with open(path, 'rb') as f:
+                    header_data = f.read(QSMP_HEADER_SIZE)
+                    if len(header_data) < QSMP_HEADER_SIZE:
+                        raise ValueError(f"Invalid .qsamples file: {path}")
+
+                    magic, version, flags, sample_count = struct.unpack('<IHHI', header_data[:12])
+                    if magic != QSMP_MAGIC:
+                        raise ValueError(f"Invalid .qsamples file: bad magic in {path}")
+                    if version > 1:
+                        raise ValueError(f"Unsupported .qsamples version in {path}: {version}")
+
+                    self.total_samples += sample_count
+                    logging.info(f"  {path}: {sample_count} samples")
+
+            logging.info(f"Total samples across all files: {self.total_samples} (streaming mode)")
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def _parse_sample(self, data: bytes) -> tuple:
+        """Parse a single TrainingSample from bytes."""
+        # CompactState (24 bytes)
+        p1_row, p1_col, p2_row, p2_col = struct.unpack('BBBB', data[0:4])
+        p1_fences, p2_fences = struct.unpack('BB', data[4:6])
+        flags = data[6]
+        fences_h, fences_v = struct.unpack('<QQ', data[8:24])
+
+        # Policy (209 floats = 836 bytes)
+        policy = np.frombuffer(data[24:24+NUM_ACTIONS*4], dtype=np.float32).copy()
+
+        # Value (1 float = 4 bytes)
+        value = struct.unpack('<f', data[24+NUM_ACTIONS*4:24+NUM_ACTIONS*4+4])[0]
+
+        # Convert to tensor format
+        state = self._state_to_tensor(
+            p1_row, p1_col, p2_row, p2_col,
+            p1_fences, p2_fences, flags,
+            fences_h, fences_v
+        )
+
+        return (
+            torch.from_numpy(state),
+            torch.from_numpy(policy),
+            torch.tensor([value], dtype=torch.float32)
+        )
+
+    def _state_to_tensor(self, p1_row, p1_col, p2_row, p2_col,
+                         p1_fences, p2_fences, flags,
+                         fences_h, fences_v) -> np.ndarray:
+        """Convert compact state to 6-channel tensor."""
+        tensor = np.zeros((6, 9, 9), dtype=np.float32)
+
+        # FLAG_P1_TO_MOVE = 0x04
+        is_p1_turn = (flags & 0x04) != 0
+
+        # Determine current player and opponent
+        if is_p1_turn:
+            my_row, my_col, my_fences = p1_row, p1_col, p1_fences
+            opp_row, opp_col, opp_fences = p2_row, p2_col, p2_fences
+        else:
+            my_row, my_col, my_fences = p2_row, p2_col, p2_fences
+            opp_row, opp_col, opp_fences = p1_row, p1_col, p1_fences
+
+        # Channel 0: Current player's pawn
+        tensor[0, my_row, my_col] = 1.0
+
+        # Channel 1: Opponent's pawn
+        tensor[1, opp_row, opp_col] = 1.0
+
+        # Channel 2: Horizontal walls
+        for r in range(8):
+            for c in range(8):
+                if (fences_h >> (r * 8 + c)) & 1:
+                    tensor[2, r, c] = 1.0
+
+        # Channel 3: Vertical walls
+        for r in range(8):
+            for c in range(8):
+                if (fences_v >> (r * 8 + c)) & 1:
+                    tensor[3, r, c] = 1.0
+
+        # Channel 4: Current player's fences
+        tensor[4, :, :] = my_fences / 10.0
+
+        # Channel 5: Opponent's fences
+        tensor[5, :, :] = opp_fences / 10.0
+
+        return tensor
+
+    def generate_batches(self):
+        """
+        Generate batches of training data from all files.
+
+        In-memory mode (default): Shuffles all samples before generating batches.
+        Streaming mode: Reads samples sequentially from files.
+        """
+        if self.stream:
+            # Streaming mode: read from files sequentially
+            states, policies, values = [], [], []
+
+            # Iterate through all files
+            for path in self.samples_paths:
+                with open(path, 'rb') as f:
+                    # Skip header
+                    f.read(QSMP_HEADER_SIZE)
+
+                    # Read all samples from this file
+                    while True:
+                        sample_data = f.read(TRAINING_SAMPLE_SIZE)
+                        if len(sample_data) < TRAINING_SAMPLE_SIZE:
+                            break
+
+                        state_t, policy_t, value_t = self._parse_sample(sample_data)
+                        states.append(state_t)
+                        policies.append(policy_t)
+                        values.append(value_t)
+
+                        # Yield batch when full
+                        if len(states) == self.batch_size:
+                            yield (
+                                torch.stack(states),
+                                torch.stack(policies),
+                                torch.stack(values)
+                            )
+                            states, policies, values = [], [], []
+
+            # Yield remaining samples
+            if states:
+                yield (
+                    torch.stack(states),
+                    torch.stack(policies),
+                    torch.stack(values)
+                )
+        else:
+            # In-memory mode: shuffle and generate batches
+            if self.samples is None:
+                raise RuntimeError("Dataset not initialized with context manager")
+
+            # Shuffle samples for better training
+            import random
+            indices = list(range(len(self.samples)))
+            random.shuffle(indices)
+
+            # Generate batches from shuffled indices
+            for i in range(0, len(indices), self.batch_size):
+                batch_indices = indices[i:i + self.batch_size]
+                states = [self.samples[idx][0] for idx in batch_indices]
+                policies = [self.samples[idx][1] for idx in batch_indices]
+                values = [self.samples[idx][2] for idx in batch_indices]
+
+                yield (
+                    torch.stack(states),
+                    torch.stack(policies),
+                    torch.stack(values)
+                )
 
 
 # =============================================================================

--- a/train/StateNode.py
+++ b/train/StateNode.py
@@ -2,6 +2,7 @@ import ctypes
 import subprocess
 import numpy as np
 import torch
+import random
 from typing import Optional
 import logging
 from io import BufferedReader
@@ -73,6 +74,15 @@ class TrainingSampleDataset:
         self.stream = stream
         self.file = None
         self.samples = None  # In-memory storage when not streaming
+        self.__enter__()
+
+    def __len__(self):
+        # In-memory mode is required for this efficient shuffling
+        return len(self.samples) if self.samples else 0
+
+    def __getitem__(self, idx):
+        # Returns (state, policy, value) for a single index
+        return self.samples[idx]
 
     def __enter__(self):
         self.file = open(self.samples_path, 'rb')
@@ -226,7 +236,6 @@ class TrainingSampleDataset:
                 raise RuntimeError("Dataset not initialized with context manager")
 
             # Shuffle samples for better training
-            import random
             indices = list(range(len(self.samples)))
             random.shuffle(indices)
 
@@ -272,6 +281,15 @@ class MultiFileTrainingSampleDataset:
         self.stream = stream
         self.total_samples = 0
         self.samples = None  # In-memory storage when not streaming
+        self.__enter__()
+
+    def __len__(self):
+        # In-memory mode is required for this efficient shuffling
+        return len(self.samples) if self.samples else 0
+
+    def __getitem__(self, idx):
+        # Returns (state, policy, value) for a single index
+        return self.samples[idx]
 
     def __enter__(self):
         if not self.stream:
@@ -447,7 +465,6 @@ class MultiFileTrainingSampleDataset:
                 raise RuntimeError("Dataset not initialized with context manager")
 
             # Shuffle samples for better training
-            import random
             indices = list(range(len(self.samples)))
             random.shuffle(indices)
 

--- a/train/model_utils.py
+++ b/train/model_utils.py
@@ -1,0 +1,97 @@
+"""Utilities for model management and identification."""
+import hashlib
+from pathlib import Path
+
+
+def compute_model_hash(model_path: str, hash_length: int = 8) -> str:
+    """
+    Compute a short hash identifier for a model file.
+
+    Uses SHA256 of the file contents and returns the first hash_length characters.
+    This provides a stable identifier for tracking which samples were generated
+    with which model version.
+
+    Args:
+        model_path: Path to the .pt model file
+        hash_length: Number of hex characters to return (default: 8)
+
+    Returns:
+        Hex string hash of the model file
+    """
+    if not Path(model_path).exists():
+        raise FileNotFoundError(f"Model file not found: {model_path}")
+
+    sha256 = hashlib.sha256()
+    with open(model_path, 'rb') as f:
+        # Read in chunks to handle large files
+        while chunk := f.read(8192):
+            sha256.update(chunk)
+
+    return sha256.hexdigest()[:hash_length]
+
+
+def find_samples_for_model(samples_dir: str, model_hash: str) -> list[Path]:
+    """
+    Find all .qsamples files generated with a specific model version.
+
+    Args:
+        samples_dir: Directory containing sample files
+        model_hash: Model hash identifier to match
+
+    Returns:
+        List of Path objects for matching sample files, sorted by iteration number
+    """
+    samples_path = Path(samples_dir)
+    if not samples_path.exists():
+        return []
+
+    # Pattern: tree_<iter#>_<modelhash>.qsamples
+    matching_files = []
+    for file in samples_path.glob(f"tree_*_{model_hash}.qsamples"):
+        matching_files.append(file)
+
+    # Sort by iteration number (extract from filename)
+    def get_iter_num(path: Path) -> int:
+        try:
+            # Extract iteration from "tree_123_abc.qsamples"
+            parts = path.stem.split('_')
+            if len(parts) >= 2:
+                return int(parts[1])
+        except (ValueError, IndexError):
+            pass
+        return 0
+
+    matching_files.sort(key=get_iter_num)
+    return matching_files
+
+
+def find_all_model_hashes(samples_dir: str) -> dict[str, list[Path]]:
+    """
+    Group all sample files by model hash.
+
+    Args:
+        samples_dir: Directory containing sample files
+
+    Returns:
+        Dictionary mapping model_hash -> list of sample file paths
+    """
+    samples_path = Path(samples_dir)
+    if not samples_path.exists():
+        return {}
+
+    hash_to_files = {}
+
+    for file in samples_path.glob("tree_*_*.qsamples"):
+        # Extract hash from "tree_123_abc.qsamples"
+        parts = file.stem.split('_')
+        if len(parts) >= 3:
+            model_hash = parts[2]
+            if model_hash not in hash_to_files:
+                hash_to_files[model_hash] = []
+            hash_to_files[model_hash].append(file)
+
+    # Sort each list by iteration number
+    for files in hash_to_files.values():
+        files.sort(key=lambda p: int(p.stem.split('_')[1]) if p.stem.split('_')[1].isdigit() else 0)
+
+    return hash_to_files

--- a/train/resnet.py
+++ b/train/resnet.py
@@ -196,7 +196,7 @@ def train(model, data_file: str, batch_size: int, num_epochs: int):
             num_batches += 1
 
             if num_batches % 100 == 0:
-                logging.info(f"Epoch {epoch}, Batch {num_batches}, Loss: {loss:.4f} (v:{v_loss:.4f} p:{p_loss:.4f})")
+                logging.debug(f"Epoch {epoch}, Batch {num_batches}, Loss: {loss:.4f} (v:{v_loss:.4f} p:{p_loss:.4f})")
 
         avg_loss = epoch_loss / num_batches
         avg_v_loss = epoch_value_loss / num_batches

--- a/train/resnet.py
+++ b/train/resnet.py
@@ -1,220 +1,267 @@
-#Eamon's resnet for valuing a gamestate of Quoridor
+# Quoridor Neural Network with Policy and Value heads (AlphaZero-style)
 import logging
 import argparse
 import sys
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
-from StateNode import QuoridorDataset
+from StateNode import QuoridorDataset, TrainingSampleDataset
 
-class QuoridorValueNet(nn.Module):
-    def __init__(self):
+# Action space:
+#   0-80:    pawn move to square (row * 9 + col)
+#   81-144:  horizontal wall at (row * 8 + col)
+#   145-208: vertical wall at (row * 8 + col)
+NUM_PAWN_ACTIONS = 81   # 9x9 board destinations
+NUM_WALL_ACTIONS = 128  # 8x8 * 2 orientations
+NUM_ACTIONS = NUM_PAWN_ACTIONS + NUM_WALL_ACTIONS  # 209 total
+
+
+class ResidualBlock(nn.Module):
+    """Standard residual block: conv -> bn -> relu -> conv -> bn -> skip -> relu"""
+    def __init__(self, channels):
         super().__init__()
-        # Input structure:
-        # Channel 1: 9x9 - P1 pawn location (binary)
-        # Channel 2: 9x9 - P2 pawn location (binary)
-        # Channel 3: 8x8 - Horizontal walls (binary) 
-        # Channel 4: 8x8 - Vertical walls (binary)
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(channels)
 
-        #pawn positions
-        self.pawn_conv = nn.Sequential(
-            nn.Conv2d(2, 32, kernel_size=3, padding=1),
-            nn.BatchNorm2d(32),
-            nn.ReLU()
-        )
+    def forward(self, x):
+        identity = x
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out = out + identity
+        return F.relu(out)
 
-        # Process wall positions (8x8)
-        self.wall_conv = nn.Sequential(
-            nn.Conv2d(2, 32, kernel_size=3, padding=1),
-            nn.BatchNorm2d(32),
-            nn.ReLU()
-        )
 
-        # Residual tower for pawn features
-        self.pawn_residual = nn.ModuleList([
-            nn.Sequential(
-                nn.Conv2d(32, 32, kernel_size=3, padding=1),
-                nn.BatchNorm2d(32),
-                nn.ReLU(),
-                nn.Conv2d(32, 32, kernel_size=3, padding=1),
-                nn.BatchNorm2d(32)
-            ) for _ in range(3)
+class QuoridorNet(nn.Module):
+    """
+    AlphaZero-style network with shared trunk, policy head, and value head.
+
+    The board is always presented from the CURRENT PLAYER's perspective:
+    - Channel 0 is always "my" pawn, Channel 1 is always opponent's pawn
+    - This means when loading P2's turn, we swap P1/P2 positions and fence counts
+    - Value output is always from current player's perspective (+1 = I'm winning)
+
+    Input: (batch, 6, 9, 9) tensor
+        [0] Current player's pawn position (one-hot)
+        [1] Opponent's pawn position (one-hot)
+        [2] Horizontal walls (padded 8x8 -> 9x9)
+        [3] Vertical walls (padded 8x8 -> 9x9)
+        [4] Current player's fences remaining / 10 (constant plane)
+        [5] Opponent's fences remaining / 10 (constant plane)
+
+    Output: (policy_logits, value)
+        policy_logits: (batch, 209) raw logits for all actions
+        value: (batch, 1) evaluation from current player's view in [-1, 1]
+    """
+
+    def __init__(self, num_channels=64, num_blocks=6):
+        super().__init__()
+        self.num_channels = num_channels
+        self.num_blocks = num_blocks
+
+        # Input convolution: 6 channels -> num_channels
+        self.input_conv = nn.Conv2d(6, num_channels, kernel_size=3, padding=1, bias=False)
+        self.input_bn = nn.BatchNorm2d(num_channels)
+
+        # Residual tower
+        self.residual_tower = nn.ModuleList([
+            ResidualBlock(num_channels) for _ in range(num_blocks)
         ])
 
-        # Residual tower for wall features
-        self.wall_residual = nn.ModuleList([
-            nn.Sequential(
-                nn.Conv2d(32, 32, kernel_size=3, padding=1),
-                nn.BatchNorm2d(32),
-                nn.ReLU(),
-                nn.Conv2d(32, 32, kernel_size=3, padding=1),
-                nn.BatchNorm2d(32)
-            ) for _ in range(3)
-        ])
+        # Policy head: conv 1x1 -> bn -> relu -> flatten -> fc
+        self.policy_conv = nn.Conv2d(num_channels, 2, kernel_size=1, bias=False)
+        self.policy_bn = nn.BatchNorm2d(2)
+        self.policy_fc = nn.Linear(2 * 9 * 9, NUM_ACTIONS)
 
-        # Feature combination layer
-        self.combine_features = nn.Sequential(
-            nn.Conv2d(64, 32, kernel_size=1),  # 1x1 conv to merge channels
-            nn.BatchNorm2d(32),
-            nn.ReLU()
-        )
+        # Value head: conv 1x1 -> bn -> relu -> flatten -> fc -> relu -> fc -> tanh
+        self.value_conv = nn.Conv2d(num_channels, 1, kernel_size=1, bias=False)
+        self.value_bn = nn.BatchNorm2d(1)
+        self.value_fc1 = nn.Linear(9 * 9, 128)
+        self.value_fc2 = nn.Linear(128, 1)
+
+    def forward(self, x):
+        # x: (batch, 6, 9, 9)
+
+        # Input convolution
+        out = F.relu(self.input_bn(self.input_conv(x)))
+
+        # Residual tower
+        for block in self.residual_tower:
+            out = block(out)
+
+        # Policy head
+        p = F.relu(self.policy_bn(self.policy_conv(out)))
+        p = p.view(p.size(0), -1)  # flatten
+        p = self.policy_fc(p)  # raw logits, no softmax (applied during training/inference)
 
         # Value head
-        self.value_head = nn.Sequential(
-            nn.Conv2d(32, 1, kernel_size=1),
-            nn.BatchNorm2d(1),
-            nn.ReLU(),
-            nn.Flatten(),
-            nn.Linear(64, 256),  # 8x8 = 64 features after flattening
-            nn.ReLU()
-        )
+        v = F.relu(self.value_bn(self.value_conv(out)))
+        v = v.view(v.size(0), -1)  # flatten
+        v = F.relu(self.value_fc1(v))
+        v = torch.tanh(self.value_fc2(v))
 
-        # Meta features processing (walls remaining + turn indicator)
-        self.meta_features = nn.Sequential(
-            nn.Linear(3, 8),
-            nn.ReLU()
-        )
+        return p, v
 
-        # Final evaluation combining all features
-        self.final_evaluation = nn.Sequential(
-            nn.Linear(256 + 8, 64),
-            nn.ReLU(),
-            nn.Linear(64, 1),
-            nn.Tanh()
-        )
 
-    def forward(self, pawn_state, wall_state, meta_state):
-        # pawn_state: batch x 2 x 9 x 9
-        # wall_state: batch x 2 x 8 x 8 (horizontal and vertical walls)
-        # meta_state: batch x 3 (walls remaining for each player + turn indicator)
+# Keep old class name as alias for backward compatibility during transition
+QuoridorValueNet = QuoridorNet
 
-        # Process pawn positions
-        x_pawns = self.pawn_conv(pawn_state)
-        for res_block in self.pawn_residual:
-            identity = x_pawns
-            x_pawns = res_block(x_pawns)
-            x_pawns += identity
-            x_pawns = torch.relu(x_pawns)
-
-        # Process wall positions
-        x_walls = self.wall_conv(wall_state)
-        for res_block in self.wall_residual:
-            identity = x_walls
-            x_walls = res_block(x_walls)
-            x_walls += identity
-            x_walls = torch.relu(x_walls)
-
-        # Downsample pawn features to 8x8 to match wall features
-        x_pawns = nn.functional.interpolate(x_pawns, size=(8, 8), mode='bilinear')
-
-        # Combine pawn and wall features
-        x_combined = torch.cat([x_pawns, x_walls], dim=1)
-        x_combined = self.combine_features(x_combined)
-
-        # Process through value head
-        value_features = self.value_head(x_combined)
-
-        # Process meta features
-        meta_features = self.meta_features(meta_state)
-
-        # Combine all features for final evaluation
-        combined = torch.cat([value_features, meta_features], dim=1)
-        final_value = self.final_evaluation(combined)
-
-        return final_value
 
 def train_step(model, optimizer, data_batch):
+    """
+    Single training step with combined policy and value loss.
+
+    Loss = MSE(value, z) + CrossEntropy(policy, pi)
+
+    Where:
+        z = game outcome from current player's perspective
+        pi = MCTS visit distribution (training target for policy)
+    """
     model.train()
-    pawn_states, wall_states, meta_states, target_values = data_batch
+    states, policy_targets, value_targets = data_batch
 
     if torch.cuda.is_available():
-            pawn_states = pawn_states.cuda()
-            wall_states = wall_states.cuda()
-            meta_states = meta_states.cuda()
-            target_values = target_values.cuda()
+        states = states.cuda()
+        policy_targets = policy_targets.cuda()
+        value_targets = value_targets.cuda()
 
     optimizer.zero_grad()
-    predicted_values = model(pawn_states, wall_states, meta_states)
-    loss = nn.MSELoss()(predicted_values, target_values)
+    policy_logits, values = model(states)
+
+    # Value loss: MSE
+    value_loss = F.mse_loss(values, value_targets)
+
+    # Policy loss: Cross-entropy with MCTS visit distribution
+    # policy_targets are visit probabilities (sum to 1), policy_logits are raw logits
+    log_probs = F.log_softmax(policy_logits, dim=1)
+    policy_loss = -torch.sum(policy_targets * log_probs, dim=1).mean()
+
+    # Combined loss (can add L2 regularization via weight_decay in optimizer)
+    loss = value_loss + policy_loss
 
     loss.backward()
     optimizer.step()
 
-    return loss.item()
+    return loss.item(), value_loss.item(), policy_loss.item()
 
-def train(model, tree_file : str, batch_size : int, num_epochs: int):
-    optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+
+def train(model, data_file: str, batch_size: int, num_epochs: int):
+    """
+    Train the model on training data.
+
+    Supports two file formats:
+    - .qsamples: Pre-computed training samples with MCTS visit distributions (preferred)
+    - .qbot: Legacy tree format with uniform policy targets (via leopard)
+    """
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=1e-4)
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, 'min', patience=5)
 
     if torch.cuda.is_available():
         model.cuda()
 
-    #while tree can reliably fit in memory, just get all batches up front
+    # Auto-detect file format and load batches
     batches = []
-    with QuoridorDataset(tree_file, batch_size) as dataset:
-        for batch in dataset.generate_batches():
-            batches.append(batch)
+    if data_file.endswith('.qsamples'):
+        # New format: pre-computed training samples with MCTS visit distributions
+        logging.info(f"Loading .qsamples file: {data_file}")
+        with TrainingSampleDataset(data_file, batch_size) as dataset:
+            for batch in dataset.generate_batches():
+                batches.append(batch)
+    else:
+        # Legacy format: tree file processed via leopard
+        logging.info(f"Loading .qbot tree file: {data_file}")
+        with QuoridorDataset(data_file, batch_size) as dataset:
+            for batch in dataset.generate_batches():
+                batches.append(batch)
+
+    if not batches:
+        logging.error("No batches loaded from data file")
+        return
+
+    logging.info(f"Loaded {len(batches)} batches from data file")
+
     for epoch in range(num_epochs):
         epoch_loss = 0
+        epoch_value_loss = 0
+        epoch_policy_loss = 0
         num_batches = 0
 
         for batch in batches:
-            loss = train_step(model, optimizer, batch)
+            loss, v_loss, p_loss = train_step(model, optimizer, batch)
             epoch_loss += loss
+            epoch_value_loss += v_loss
+            epoch_policy_loss += p_loss
             num_batches += 1
 
             if num_batches % 100 == 0:
-                logging.info(f"Epoch {epoch}, Batch {num_batches}, Loss: {loss:.4f}")
+                logging.info(f"Epoch {epoch}, Batch {num_batches}, Loss: {loss:.4f} (v:{v_loss:.4f} p:{p_loss:.4f})")
 
-        if num_batches == 0:
-            logging.error("Num batches is 0, not training")
-            return
         avg_loss = epoch_loss / num_batches
+        avg_v_loss = epoch_value_loss / num_batches
+        avg_p_loss = epoch_policy_loss / num_batches
         scheduler.step(avg_loss)
 
-        logging.info(f"Epoch {epoch}, Average Loss: {avg_loss:.4f}")
+        logging.info(f"Epoch {epoch}, Avg Loss: {avg_loss:.4f} (value:{avg_v_loss:.4f} policy:{avg_p_loss:.4f})")
+
 
 def main():
-    parser = argparse.ArgumentParser(description='Train Quoridor Value Network')
+    parser = argparse.ArgumentParser(description='Train Quoridor Policy-Value Network')
     parser.add_argument('--load-tree', type=str, dest="load_tree", help='Path to load search tree')
     parser.add_argument('--load-model', type=str, dest="load_model", help='Path to load model weights')
     parser.add_argument('--save-model', type=str, dest="save_model", help='Path to save model weights')
-    parser.add_argument('--export', dest="export", help='Will save inferencable version of model and exit', action='store_true', default=False)
+    parser.add_argument('--export', dest="export", help='Export TorchScript model for C++ inference',
+                        action='store_true', default=False)
     parser.add_argument('--batch-size', type=int, dest="batch_size", default=64, help='Training batch size')
     parser.add_argument('--epochs', type=int, default=100, help='Number of training epochs')
-    parser.add_argument('--log-level', dest="log_level", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'], 
+    parser.add_argument('--channels', type=int, default=64, help='Number of channels in residual tower')
+    parser.add_argument('--blocks', type=int, default=6, help='Number of residual blocks')
+    parser.add_argument('--log-level', dest="log_level", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
                        default='INFO', help='Logging level')
 
     args = parser.parse_args()
 
     logging.basicConfig(level=getattr(logging, args.log_level))
 
-    model = QuoridorValueNet()
+    model = QuoridorNet(num_channels=args.channels, num_blocks=args.blocks)
+    logging.info(f"Created model with {args.channels} channels, {args.blocks} residual blocks")
+
     if args.load_model:
-        logging.info(f"Loading {args.load_model}")
-        model.load_state_dict(torch.load(args.load_model))
+        logging.info(f"Loading weights from {args.load_model}")
+        model.load_state_dict(torch.load(args.load_model, weights_only=True))
 
-        if args.export:
-            model.eval()
+    if args.export:
+        if not args.save_model:
+            logging.error("--save-model required with --export")
+            sys.exit(1)
 
-            # Create example inputs for tracing
-            example_pawn_state = torch.zeros(1, 2, 9, 9)
-            example_wall_state = torch.zeros(1, 2, 8, 8)
-            example_meta_state = torch.zeros(1, 3)
+        model.eval()
 
-            # Use TorchScript to create a serializable version
-            traced_script_module = torch.jit.trace(model, (example_pawn_state, example_wall_state, example_meta_state))
+        # Save trainable weights (.model file for continued training)
+        weights_path = args.save_model.replace('.pt', '.model')
+        if weights_path == args.save_model:
+            weights_path = args.save_model + '.model'
+        torch.save(model.state_dict(), weights_path)
+        logging.info(f"Saved trainable weights to {weights_path}")
 
-            # Save the model
-            traced_script_module.save(args.save_model)
-            sys.exit(0)
+        # Export TorchScript model (.pt file for C++ inference)
+        example_input = torch.zeros(1, 6, 9, 9)
+        traced_model = torch.jit.trace(model, example_input)
+        traced_model.save(args.save_model)
+        logging.info(f"Exported TorchScript model to {args.save_model}")
+        sys.exit(0)
 
+    if not args.load_tree:
+        logging.error("--load-tree required for training")
+        sys.exit(1)
 
     train(model, args.load_tree, args.batch_size, args.epochs)
 
     if args.save_model:
         torch.save(model.state_dict(), args.save_model)
+        logging.info(f"Saved model weights to {args.save_model}")
+
 
 if __name__ == "__main__":
     main()
-

--- a/train/train_loop.py
+++ b/train/train_loop.py
@@ -409,18 +409,17 @@ def main():
             return
         save_checkpoint(model, str(current_best_weights))
 
-    # Find starting iteration
-    start_iter = get_next_iteration(str(samples_dir))
-    logging.info(f"Starting from iteration {start_iter}")
+    ## see what sample numbering we're starting on
+    sample_num = get_next_iteration(str(samples_dir))
 
     promotions = 0
     rejections = 0
 
-    for iteration in range(start_iter, start_iter + args.iterations):
+    for iteration in range(args.iterations):
         logging.info("")
         logging.info(f"{'=' * 20} ITERATION {iteration} {'=' * 20}")
 
-        tree_path = samples_dir / f"tree_{iteration}.qbot"
+        tree_path = samples_dir / f"tree_{sample_num}.qbot"
 
         # Phase 1: Self-play
         logging.info(f"[Phase 1] Self-play ({args.games} games)...")
@@ -436,6 +435,8 @@ def main():
             logging.error(f"Training samples not found at {samples_path}")
             logging.error("Self-play should generate .qsamples files automatically")
             continue
+        else:
+            sample_num += 1
 
         logging.info(f"Using training samples: {samples_path}")
 

--- a/train/train_loop.py
+++ b/train/train_loop.py
@@ -426,7 +426,7 @@ def main():
         logging.info(f"[Phase 1] Self-play ({args.games} games)...")
         if not run_selfplay(str(tree_path), str(current_best_pt), args.games,
                             args.simulations, args.threads,
-                            args.temperature, args.temp_drop):
+                            args.temperature, args.temp_drop, args.max_memory):
             logging.error("Self-play failed, retrying iteration...")
             continue
 

--- a/train/train_loop.py
+++ b/train/train_loop.py
@@ -2,14 +2,17 @@
 """
 AlphaZero-style training loop for Quoridor.
 
-Alternates between:
-1. Training neural network on completed games in the tree
-2. Building more tree using the trained neural network
+Full loop:
+1. Self-play: Generate games using current best model, save to samples/tree_X.qbot
+2. Train: Train candidate model on generated data, export to model/candidate.pt
+3. Arena: Evaluate candidate vs current_best, promote if candidate wins
 """
 
 import argparse
 import logging
 import os
+import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -21,6 +24,21 @@ from resnet import QuoridorValueNet, train
 def get_project_root():
     """Get the project root directory."""
     return Path(__file__).parent.parent
+
+
+def get_next_iteration(samples_dir: str) -> int:
+    """Find the next iteration number based on existing tree files."""
+    samples_path = Path(samples_dir)
+    if not samples_path.exists():
+        return 0
+
+    max_iter = -1
+    for f in samples_path.glob("tree_*.qbot"):
+        match = re.match(r"tree_(\d+)\.qbot", f.name)
+        if match:
+            max_iter = max(max_iter, int(match.group(1)))
+
+    return max_iter + 1
 
 
 def run_selfplay(tree_path: str, model_path: str, num_games: int,
@@ -37,6 +55,10 @@ def run_selfplay(tree_path: str, model_path: str, num_games: int,
         logging.error(f"Model file required for self-play: {model_path}")
         return False
 
+    # Ensure output directory exists
+    tree_dir = Path(tree_path).parent
+    tree_dir.mkdir(parents=True, exist_ok=True)
+
     cmd = [
         str(qbot_path),
         "--selfplay",
@@ -49,17 +71,11 @@ def run_selfplay(tree_path: str, model_path: str, num_games: int,
         "--temp-drop", str(temp_drop_ply),
     ]
 
-    # Load existing tree if it exists
-    if os.path.exists(tree_path):
-        cmd.extend(["-l", tree_path])
-
     logging.info(f"Running: {' '.join(cmd)}")
     logging.info(f"Playing {num_games} self-play games...")
 
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
-        # Self-play runs to completion
         stdout, _ = proc.communicate(timeout=3600 * 4)  # 4 hour timeout
         if stdout:
             lines = stdout.decode().strip().split('\n')
@@ -93,11 +109,9 @@ def check_tree_has_games(tree_path: str) -> int:
             timeout=60
         )
 
-        # Parse stderr for terminal node count
         stderr = result.stderr.decode()
         for line in stderr.split('\n'):
             if "terminal nodes" in line:
-                # "Found X terminal nodes (completed games)"
                 parts = line.split()
                 if len(parts) >= 2:
                     return int(parts[1])
@@ -125,12 +139,14 @@ def export_model(model: QuoridorValueNet, export_path: str) -> bool:
     """Export model to TorchScript for C++ inference."""
     logging.info(f"Exporting model to {export_path}")
 
+    # Ensure output directory exists
+    export_dir = Path(export_path).parent
+    export_dir.mkdir(parents=True, exist_ok=True)
+
     try:
         model.eval()
-        model.cpu()  # Ensure model is on CPU for export
+        model.cpu()
 
-        # Create example inputs for tracing
-        # meta has 3 elements: p1_fences, p2_fences, turn_indicator
         example_pawn = torch.zeros(1, 2, 9, 9)
         example_wall = torch.zeros(1, 2, 8, 8)
         example_meta = torch.zeros(1, 3)
@@ -146,6 +162,9 @@ def export_model(model: QuoridorValueNet, export_path: str) -> bool:
 
 def save_checkpoint(model: QuoridorValueNet, checkpoint_path: str) -> bool:
     """Save model weights checkpoint."""
+    checkpoint_dir = Path(checkpoint_path).parent
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
     try:
         torch.save(model.state_dict(), checkpoint_path)
         logging.info(f"Saved checkpoint to {checkpoint_path}")
@@ -155,24 +174,73 @@ def save_checkpoint(model: QuoridorValueNet, checkpoint_path: str) -> bool:
         return False
 
 
+def run_arena(current_model: str, candidate_model: str, num_games: int,
+              simulations: int, win_threshold: float = 0.55) -> tuple[bool, bool]:
+    """
+    Run arena evaluation between candidate and current model.
+    Returns (success, candidate_won).
+    """
+    qbot_path = get_project_root() / "build" / "qbot"
+
+    if not qbot_path.exists():
+        logging.error(f"qbot not found at {qbot_path}")
+        return False, False
+
+    cmd = [
+        str(qbot_path),
+        "--arena",
+        "-m", current_model,
+        "--candidate", candidate_model,
+        "--arena-games", str(num_games),
+        "-n", str(simulations),
+        "--win-threshold", str(win_threshold),
+    ]
+
+    logging.info(f"Running arena: {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=3600 * 2)
+        output = result.stdout.decode() + result.stderr.decode()
+
+        # Log last lines of output
+        lines = output.strip().split('\n')
+        for line in lines[-15:]:
+            logging.info(f"  {line}")
+
+        if result.returncode != 0:
+            logging.error("Arena evaluation failed")
+            return False, False
+
+        # Check if candidate won by looking for "Candidate wins!" or "promoted"
+        candidate_won = "Candidate wins!" in output or "promoted successfully" in output
+
+        return True, candidate_won
+
+    except subprocess.TimeoutExpired:
+        logging.error("Arena evaluation timed out")
+        return False, False
+    except Exception as e:
+        logging.error(f"Error running arena: {e}")
+        return False, False
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='AlphaZero-style training loop for Quoridor',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    # Paths
-    parser.add_argument('--tree', type=str, default='tree.qbot',
-                        help='Path to tree file')
-    parser.add_argument('--model', type=str, default='treestyle.model',
-                        help='Path to model weights file')
-    parser.add_argument('--export-model', type=str, default='treestyle.pt',
-                        dest='export_model',
-                        help='Path to exported TorchScript model')
+    # Directories
+    parser.add_argument('--samples-dir', type=str, default='samples',
+                        dest='samples_dir',
+                        help='Directory for tree samples (tree_X.qbot files)')
+    parser.add_argument('--model-dir', type=str, default='model',
+                        dest='model_dir',
+                        help='Directory for models')
 
     # Training parameters
-    parser.add_argument('--iterations', type=int, default=10,
-                        help='Number of train/selfplay iterations')
+    parser.add_argument('--iterations', type=int, default=100,
+                        help='Number of training iterations')
     parser.add_argument('--games', type=int, default=500,
                         help='Self-play games per iteration')
     parser.add_argument('--simulations', type=int, default=800,
@@ -188,10 +256,18 @@ def main():
     parser.add_argument('--temp-drop', type=int, default=30, dest='temp_drop',
                         help='Ply at which to drop temperature to 0')
 
+    # Arena parameters
+    parser.add_argument('--arena-games', type=int, default=100, dest='arena_games',
+                        help='Number of arena games for evaluation')
+    parser.add_argument('--arena-sims', type=int, default=400, dest='arena_sims',
+                        help='MCTS simulations per move in arena')
+    parser.add_argument('--win-threshold', type=float, default=0.55,
+                        dest='win_threshold',
+                        help='Win rate threshold for model promotion')
+
     # Options
-    parser.add_argument('--skip-initial-build', action='store_true',
-                        dest='skip_initial_build',
-                        help='Skip initial tree building (use existing tree)')
+    parser.add_argument('--skip-arena', action='store_true', dest='skip_arena',
+                        help='Skip arena evaluation (always promote candidate)')
     parser.add_argument('--log-level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
                         default='INFO', dest='log_level',
                         help='Logging level')
@@ -204,87 +280,151 @@ def main():
         datefmt='%H:%M:%S'
     )
 
+    # Resolve paths
+    project_root = get_project_root()
+    samples_dir = project_root / args.samples_dir
+    model_dir = project_root / args.model_dir
+
+    current_best_pt = model_dir / "current_best.pt"
+    candidate_pt = model_dir / "candidate.pt"
+    current_best_weights = model_dir / "current_best.model"
+    candidate_weights = model_dir / "candidate.model"
+
+    # Ensure directories exist
+    samples_dir.mkdir(parents=True, exist_ok=True)
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    logging.info("=" * 60)
+    logging.info("Quoridor AlphaZero Training Loop")
+    logging.info("=" * 60)
+    logging.info(f"Samples dir:     {samples_dir}")
+    logging.info(f"Model dir:       {model_dir}")
+    logging.info(f"Current best:    {current_best_pt}")
+    logging.info(f"Candidate:       {candidate_pt}")
+    logging.info(f"Iterations:      {args.iterations}")
+    logging.info(f"Games/iter:      {args.games}")
+    logging.info(f"Sims/move:       {args.simulations}")
+    logging.info(f"Temperature:     {args.temperature} (drops at ply {args.temp_drop})")
+    logging.info(f"Epochs:          {args.epochs} per iteration")
+    logging.info(f"Threads:         {args.threads}")
+    logging.info(f"Arena games:     {args.arena_games}")
+    logging.info(f"Win threshold:   {args.win_threshold * 100}%")
+    logging.info("=" * 60)
+
     # Initialize model
     model = QuoridorValueNet()
 
-    # Load existing model if available
-    if os.path.exists(args.model):
-        logging.info(f"Loading existing model from {args.model}")
-        model.load_state_dict(torch.load(args.model))
+    # Load existing best model weights if available
+    if current_best_weights.exists():
+        logging.info(f"Loading existing model from {current_best_weights}")
+        model.load_state_dict(torch.load(current_best_weights))
+    elif current_best_pt.exists():
+        logging.info("No weights file found, will use existing TorchScript model")
+    else:
+        logging.info("Starting with fresh random model")
 
     # Use GPU if available
     if torch.cuda.is_available():
         model.cuda()
         logging.info("Using CUDA")
 
-    # Resolve paths
-    tree_path = os.path.abspath(args.tree)
-    model_path = os.path.abspath(args.model)
-    export_path = os.path.abspath(args.export_model)
-
-    logging.info("=" * 60)
-    logging.info("Quoridor AlphaZero Training Loop (Self-Play)")
-    logging.info("=" * 60)
-    logging.info(f"Tree file:      {tree_path}")
-    logging.info(f"Model file:     {model_path}")
-    logging.info(f"Export file:    {export_path}")
-    logging.info(f"Iterations:     {args.iterations}")
-    logging.info(f"Games/iter:     {args.games}")
-    logging.info(f"Sims/move:      {args.simulations}")
-    logging.info(f"Temperature:    {args.temperature} (drops at ply {args.temp_drop})")
-    logging.info(f"Epochs:         {args.epochs} per iteration")
-    logging.info(f"Threads:        {args.threads}")
-    logging.info("=" * 60)
-
-    # Export initial model (required for self-play)
-    if not os.path.exists(export_path):
-        logging.info("Exporting initial model for self-play...")
-        if not export_model(model, export_path):
+    # Export initial model if needed
+    if not current_best_pt.exists():
+        logging.info("Exporting initial model as current_best...")
+        if not export_model(model, str(current_best_pt)):
             logging.error("Failed to export initial model")
             return
+        save_checkpoint(model, str(current_best_weights))
 
-    for iteration in range(args.iterations):
+    # Find starting iteration
+    start_iter = get_next_iteration(str(samples_dir))
+    logging.info(f"Starting from iteration {start_iter}")
+
+    promotions = 0
+    rejections = 0
+
+    for iteration in range(start_iter, start_iter + args.iterations):
         logging.info("")
-        logging.info(f"{'=' * 20} ITERATION {iteration + 1}/{args.iterations} {'=' * 20}")
+        logging.info(f"{'=' * 20} ITERATION {iteration} {'=' * 20}")
 
-        # Phase 1: Self-play (skip on first iteration if requested and tree exists)
-        if iteration == 0 and args.skip_initial_build and os.path.exists(tree_path):
-            logging.info("Skipping initial self-play (using existing tree)")
-        else:
-            logging.info(f"[Phase 1] Self-play ({args.games} games)...")
-            if not run_selfplay(tree_path, export_path, args.games, args.simulations,
-                                args.threads, args.temperature, args.temp_drop):
-                logging.error("Self-play failed")
-                continue
+        tree_path = samples_dir / f"tree_{iteration}.qbot"
+
+        # Phase 1: Self-play
+        logging.info(f"[Phase 1] Self-play ({args.games} games)...")
+        if not run_selfplay(str(tree_path), str(current_best_pt), args.games,
+                            args.simulations, args.threads,
+                            args.temperature, args.temp_drop):
+            logging.error("Self-play failed, retrying iteration...")
+            continue
 
         # Check if tree has completed games
-        num_games = check_tree_has_games(tree_path)
+        num_games = check_tree_has_games(str(tree_path))
         if num_games == 0:
             logging.warning("No completed games in tree, skipping training")
             continue
 
-        logging.info(f"Tree has {num_games} terminal nodes (completed games)")
+        logging.info(f"Tree has {num_games} terminal nodes")
 
-        # Phase 2: Train neural network
-        logging.info(f"[Phase 2] Training neural network...")
-        if not train_model(model, tree_path, args.epochs, args.batch_size):
-            logging.error("Training failed")
+        # Phase 2: Train candidate model
+        logging.info(f"[Phase 2] Training candidate neural network...")
+
+        # Reload current best weights before training
+        if current_best_weights.exists():
+            model.load_state_dict(torch.load(current_best_weights))
+            if torch.cuda.is_available():
+                model.cuda()
+
+        if not train_model(model, str(tree_path), args.epochs, args.batch_size):
+            logging.error("Training failed, skipping iteration...")
             continue
 
-        # Save checkpoint and export updated model for next iteration
-        save_checkpoint(model, model_path)
-        export_model(model, export_path)
+        # Export candidate
+        save_checkpoint(model, str(candidate_weights))
+        export_model(model, str(candidate_pt))
 
-        logging.info(f"Iteration {iteration + 1} complete")
+        # Phase 3: Arena evaluation
+        if args.skip_arena:
+            logging.info("[Phase 3] Arena skipped, promoting candidate...")
+            candidate_won = True
+            arena_success = True
+        else:
+            logging.info(f"[Phase 3] Arena evaluation ({args.arena_games} games)...")
+            arena_success, candidate_won = run_arena(
+                str(current_best_pt), str(candidate_pt),
+                args.arena_games, args.arena_sims, args.win_threshold
+            )
 
-    # Final export
+            if not arena_success:
+                logging.error("Arena evaluation failed, keeping current model...")
+                rejections += 1
+                continue
+
+        # Handle result
+        if candidate_won:
+            promotions += 1
+            logging.info(f"Candidate PROMOTED! (total promotions: {promotions})")
+            # Copy candidate to current_best
+            shutil.copy(str(candidate_pt), str(current_best_pt))
+            shutil.copy(str(candidate_weights), str(current_best_weights))
+        else:
+            rejections += 1
+            logging.info(f"Candidate rejected. (total rejections: {rejections})")
+            # Reload current best weights for next iteration
+            if current_best_weights.exists():
+                model.load_state_dict(torch.load(current_best_weights))
+                if torch.cuda.is_available():
+                    model.cuda()
+
+        logging.info(f"Iteration {iteration} complete. "
+                     f"Promotions: {promotions}, Rejections: {rejections}")
+
+    # Final summary
     logging.info("")
     logging.info("=" * 60)
     logging.info("Training complete!")
-    export_model(model, export_path)
-    save_checkpoint(model, model_path)
-    logging.info(f"Final model saved to {model_path}")
-    logging.info(f"TorchScript model saved to {export_path}")
+    logging.info(f"  Total promotions: {promotions}")
+    logging.info(f"  Total rejections: {rejections}")
+    logging.info(f"  Final model: {current_best_pt}")
     logging.info("=" * 60)
 
 

--- a/train/train_loop.py
+++ b/train/train_loop.py
@@ -43,7 +43,8 @@ def get_next_iteration(samples_dir: str) -> int:
 
 def run_selfplay(tree_path: str, model_path: str, num_games: int,
                  simulations: int, num_threads: int,
-                 temperature: float = 1.0, temp_drop_ply: int = 30) -> bool:
+                 temperature: float = 1.0, temp_drop_ply: int = 30,
+                 max_memory: int = 30) -> bool:
     """Run self-play games using NN-only MCTS evaluation."""
     qbot_path = get_project_root() / "build" / "qbot"
 
@@ -69,6 +70,7 @@ def run_selfplay(tree_path: str, model_path: str, num_games: int,
         "-s", tree_path,
         "--temperature", str(temperature),
         "--temp-drop", str(temp_drop_ply),
+        "--max-memory", str(max_memory),
     ]
 
     logging.info(f"Running: {' '.join(cmd)}")
@@ -259,6 +261,8 @@ def main():
                         help='Temperature for move selection')
     parser.add_argument('--temp-drop', type=int, default=30, dest='temp_drop',
                         help='Ply at which to drop temperature to 0')
+    parser.add_argument('--max-memory', type=int, default=30, dest='max_memory',
+                        help='max memory in GB, resets pool at 80%')
 
     # Arena parameters
     parser.add_argument('--arena-games', type=int, default=100, dest='arena_games',


### PR DESCRIPTION
Huge update.

- True self play turned on, parallelized with a gpu inference server so we can queue nodes and batch their eval.
- added policy head to the NN. now have policy priors and don't need to eval every child node to get priors.
- tried one off expansion, ie just making single child node at a time, too complicated, set it aside.
- draw scoring so we can factor in who was closest at 80 (arbitrary) moves in arena.
- in selfplay, terminate as soon as we run out of fences.
- added memory resets, ie when we're nearing mem limits pause workers, reset the tree, start with new tree.
- added sample viewer to see what the network is actually training on
- improved train_loop a lot, big change is tracks model hash and keeps building corpus of samples until new model is promoted, so all samples produced during selfplay with current_best are trained on each loop.